### PR TITLE
Adjustments to multithread settings and additional comments.

### DIFF
--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -26,38 +26,6 @@ void HaplotagProcess::compressParser(std::string &variantFile){
         std::cerr<< "Fail to open vcf: " << variantFile << "\n";
     }
     else{  
-        /*char buffer[1048576]; // 1M
-        char* offset = buffer;
-            
-        while(true) {
-            int len = sizeof(buffer)-(offset-buffer);
-            if (len == 0){
-                std::cerr<<"Buffer to small for input line lengths\n";
-                exit(EXIT_FAILURE);
-            }
-
-            len = gzread(file, offset, len);
-
-            if (len == 0) break;    
-            if (len <  0){ 
-                int err;
-                fprintf (stderr, "Error: %s.\n", gzerror(file, &err));
-                exit(EXIT_FAILURE);
-            }
-
-            char* cur = buffer;
-            char* end = offset+len;
-
-            for (char* eol; (cur<end) && (eol = std::find(cur, end, '\n')) < end; cur = eol + 1)
-            {
-                std::string input = std::string(cur, eol);
-                parserProcess(input);
-            }
-            // any trailing data in [eol, end) now is a partial line
-            offset = std::copy(cur, end, buffer);
-        }
-        gzclose (file);*/
-        
         int buffer_size = 1048576; // 1M
         char* buffer = (char*) malloc(buffer_size);
         if(!buffer){
@@ -362,19 +330,6 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
 
         std::map<int, RefAlt>::reverse_iterator last = currentVariants.rbegin();
 
-        //int chunkSize = chrLength[chr]/params.numThreads + params.numThreads;
-        //char *bamList[params.numThreads];
-        //for(int i=0;i<params.numThreads;i++){
-        //    std::string tmp = chr + ":" + std::to_string(i*chunkSize+1) + "-" + std::to_string((i+1)*chunkSize);
-        //    bamList[i] = new char[tmp.length()+1];
-        //    strcpy(bamList[i], tmp.c_str());
-        //}
-        //hts_itr_multi_t *iter;
-        //if( (iter = sam_itr_regarray(idx, bamHdr, bamList, params.numThreads)) == 0){
-        //    std::cerr<<"Warning: Cannot open iterator for " << chr << " for bam file\n";
-        //    continue;
-        //}
-
         std::string range = chr + ":1-" + std::to_string(chrLength[chr]);
         hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
 
@@ -475,14 +430,8 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
     int ref_pos = aln.core.pos;
     // position relative to read
     int query_pos = 0;
-    // translation char* to string;
-//    std::string qseq = align.qseq;
-    // translation char* to string;
-
     // set variant start for current alignment
     std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
-
-    //std::map<int, RefAlt>::reverse_iterator last = currentVariants.rbegin();
 
     // reading cigar to detect snp on this read
     int aln_core_n_cigar = int(aln.core.n_cigar);

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -326,13 +326,13 @@ std::vector<std::string> SnpParser::getChrVec(){
     return chrName;
 }
 
-bool SnpParser::findChromosome(std::string chrName){
+/*bool SnpParser::findChromosome(std::string chrName){
     std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
     // this chromosome not exist in this file. 
     if(chrVariantIter == chrVariant->end())
         return false;
     return true;
-}
+}*/
 
 int SnpParser::getLastSNP(std::string chrName){
     std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
@@ -528,6 +528,7 @@ void SnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariant
     std::map<int, std::map<int, std::map<int, bool> > > posAlleleStrand;
     std::map< int, bool > methylation;
     
+    /*
     // iter all variant, record the strand contained in each SNP
     for( auto readSNPVecIter : readVariantVec ){
         // tag allele on forward or reverse strand
@@ -535,6 +536,7 @@ void SnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariant
             posAlleleStrand[variantIter.position][variantIter.allele][readSNPVecIter.is_reverse] = true;
         }
     }
+    
     // iter all SNP, both alleles that require SNP need to appear in the two strand
     for(auto pos: posAlleleStrand){
         // this position contain two allele, REF allele appear in the two strand, ALT allele appear in the two strand
@@ -545,6 +547,7 @@ void SnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariant
             //methylation[pos.first] = true;
         }
     }
+    */
 
     // Filter SNPs that are not easy to phasing due to homopolymer
     // get variant list
@@ -575,7 +578,6 @@ void SnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariant
         }
         
     }
-    
     
     // iter all reads
     for( std::vector<ReadVariant>::iterator readSNPVecIter = readVariantVec.begin() ; readSNPVecIter != readVariantVec.end() ; readSNPVecIter++ ){
@@ -995,9 +997,7 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
 
     // position relative to read
     int query_pos = 0;
-//    int prev_query_pos = 0;
     // translation char* to string;
-//    std::string qseq = align.qseq;
 
     // set variant start for current alignment
     std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
@@ -1095,7 +1095,11 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                 //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
                 if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
                     
-//                    std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
+                    // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
+                    
+                    // uint8_t *qstring = bam_get_seq(aln); 
+                    // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
+                    // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
 
                     if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 1 ) {
                         allele = 1 ;
@@ -1129,13 +1133,12 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                 }
                 currentVariantIter++;
             }
-//            prev_query_pos = query_pos;
+            
             query_pos += length;
             ref_pos += length;
         }
         // 1: insertion to the reference
         else if( cigar_op == 1 ){
-//            prev_query_pos = query_pos;
             query_pos += length;
         }
         // 2: deletion from the reference
@@ -1179,9 +1182,9 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                         
                         // the read deletion contain VCF's deletion
                         if( refAlleleLen != 1 && altAlleleLen == 1){
-//                            std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
-//                            std::string refSeq = (*currentVariantIter).second.Ref;
-//                            std::string altSeq = (*currentVariantIter).second.Alt;
+                            //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
+                            //std::string refSeq = (*currentVariantIter).second.Ref;
+                            //std::string altSeq = (*currentVariantIter).second.Alt;
 
                             allele = 1;
                             // using this quality to identify indel
@@ -1211,7 +1214,6 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
         }
         // 4: soft clipping (clipped sequences present in SEQ)
         else if( cigar_op == 4 ){
-//            prev_query_pos = query_pos;
             query_pos += length;
         }
         // 5: hard clipping (clipped sequences NOT present in SEQ)

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -39,8 +39,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     ChrPhasingResult chrPhasingResult;
     // Initialize an empty map in chrPhasingResult to store all phasing results.
     // This is done to prevent issues with multi-threading, by defining an empty map first.
-    for (std::vector<std::string>::iterator chrIter = chrName.begin(); chrIter != chrName.end(); chrIter++)
-    {
+    for (std::vector<std::string>::iterator chrIter = chrName.begin(); chrIter != chrName.end(); chrIter++)    {
         chrPhasingResult[*chrIter] = PhasingResult();
     }
     
@@ -48,56 +47,55 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     int chrNumThreads,bamParserNumThreads;
     setNumThreads(chrName.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
     begin = time(NULL);
+    
     // loop all chromosome
     #pragma omp parallel for schedule(dynamic) num_threads(chrNumThreads)
     for(std::vector<std::string>::iterator chrIter = chrName.begin(); chrIter != chrName.end() ; chrIter++ ){
-        std::cerr<< "parsing contig/chromosome ... " << (*chrIter) << "\n";
+        
         std::time_t chrbegin = time(NULL);
         
+        // get lase SNP variant position
         int lastSNPpos = snpFile.getLastSNP((*chrIter));
-        // this chromosome not exist in this file. no variant on this chromosome. 
-        if( !snpFile.findChromosome((*chrIter)) || lastSNPpos == -1 ){
-            std::cerr<< "skip ... "<< (*chrIter) << "\n";
+        // therer is no variant on SNP file. 
+        if( lastSNPpos == -1 ){
             continue;
         }
-        
-        // store variant
-        std::vector<ReadVariant> readVariantVec;
 
-        std::cerr<< "fetch SNP ... " << (*chrIter) << "\n";
-        // this method does not store the read information to be used
+        // create a bam parser object and prepare to fetch varint from each vcf file
         BamParser *bamParser = new BamParser((*chrIter), params.bamFile, snpFile, svFile, modFile);
+        // fetch chromosome string
         std::string chr_reference = fastaParser.chrString.at(*chrIter);
+        // use to store variant
+        std::vector<ReadVariant> readVariantVec;
+        // run fetch variant process
         bamParser->direct_detect_alleles(lastSNPpos, bamParserNumThreads, params, readVariantVec ,chr_reference);
+        // free memory
+        delete bamParser;
         
+        // filter variants prone to switch errors in ONT sequencing.
         if(params.isONT){
-            std::cerr<< "filter SNP ... " << (*chrIter) << "\n";
             snpFile.filterSNP((*chrIter), readVariantVec, chr_reference);
         }
 
-        delete bamParser;
-
         // bam files are partial file or no read support this chromosome's SNP
         if( readVariantVec.size() == 0 ){
-            std::cerr<< "skip ... "<< (*chrIter) << "\n";
             continue;
         }
         
-        std::cerr<< "run algorithm ... " << (*chrIter) << "\n";
-        
+        // create a graph object and prepare to phasing.
         VairiantGraph *vGraph = new VairiantGraph(chr_reference, params);
         // trans read-snp info to edge info
         vGraph->addEdge(readVariantVec);
-        
         // run main algorithm
         vGraph->phasingProcess();
         // push result to phasingResult
         vGraph->exportResult((*chrIter), chrPhasingResult[*chrIter]);
-        
-        //  generate dot file
-        if(params.generateDot)
+        // generate dot file
+        if(params.generateDot){
             vGraph->writingDotFile((*chrIter));
+        }
         
+        // release the memory used by the object.
         vGraph->destroy();
         
         // free memory
@@ -105,27 +103,34 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
         readVariantVec.shrink_to_fit();
         delete vGraph;
         
-        std::cerr<< "end parsing " << (*chrIter) << " ... " << difftime(time(NULL), chrbegin) << "s\n";
+        std::cerr<< "(" << (*chrIter) << "," << difftime(time(NULL), chrbegin) << "s)";
     }
-    std::cerr<< "parsing total ... " << difftime(time(NULL), begin) << "s\n";
-    std::cerr<< "writeResult ... ";
+    
+    std::cerr<< "\nparsing total:  " << difftime(time(NULL), begin) << "s\n";
+    
     begin = time(NULL);
+    std::cerr<< "merge results ... ";
     // Create a container for merged phasing results.
     PhasingResult mergedPhasingResult;
     // Merge phasing results from all chromosomes.
-    mergeAllChrPhasingResult(chrPhasingResult,mergedPhasingResult);
+    mergeAllChrPhasingResult(chrPhasingResult, mergedPhasingResult);
+    std::cerr<< difftime(time(NULL), begin) << "s\n";
+    
+    begin = time(NULL);
+    std::cerr<< "writeResult SNP ... ";
     snpFile.writeResult(mergedPhasingResult);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
+    
     if(params.svFile!=""){
-        std::cerr<< "write SV Result ... ";
         begin = time(NULL);
+        std::cerr<< "write SV Result ... ";
         svFile.writeResult(mergedPhasingResult);
         std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
     
     if(params.modFile!=""){
-        std::cerr<< "write mod Result ... ";
         begin = time(NULL);
+        std::cerr<< "write mod Result ... ";
         modFile.writeResult(mergedPhasingResult);
         std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
@@ -134,6 +139,5 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
 };
 
 PhasingProcess::~PhasingProcess(){
-    
 };
 

--- a/Util.cpp
+++ b/Util.cpp
@@ -12,20 +12,26 @@ void mergeAllChrPhasingResult(const ChrPhasingResult& allChrPhasingResults, Phas
 }
 
 void setNumThreads(const int& defaultChrThreads,const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads){
-    chrNumThreads = defaultChrThreads;
-    bamParserNumThreads = 5;
-    if(availableThreads > 0){
-        if(availableThreads <= 24){
-            chrNumThreads = availableThreads;
-            bamParserNumThreads = 1;
-
-        }else if(availableThreads <= 48){
-            chrNumThreads = 12;
-            bamParserNumThreads = std::max(1, availableThreads / 12);
-        }else{
-            chrNumThreads = availableThreads / 4;
-            bamParserNumThreads = 4;
-        }
+    if(availableThreads == 0){
+        // The default thread value is 0, indicating that each chromosome concurrently utilizes 
+        // a single thread for computation. Due to the limited multithreading acceleration space 
+        // in htslib and an average utilization of no more than 5 threads per chromosome, the 
+        // default value is set to 5.
+        chrNumThreads = defaultChrThreads;
+        bamParserNumThreads = 5;
+    }
+    else if( defaultChrThreads > availableThreads){
+        // Due to the number of available threads being less than the number of chromosomes, 
+        // processing is performed on a subset of chromosomes equal to the availableThreads count, 
+        // with a limitation on the number of threads for reading the BAM file for each chromosome.
+        chrNumThreads = availableThreads;
+        bamParserNumThreads = 1;
+    }
+    else{
+        // If the number of available threads exceeds the count of chromosomes, the surplus 
+        // threads will be utilized to accelerate the speed of htslib in parsing BAM files.
+        chrNumThreads = defaultChrThreads;
+        bamParserNumThreads = std::max(1,availableThreads/defaultChrThreads);
     }
 }
 


### PR DESCRIPTION
### Summary
1. Modify the initialization settings and runtime prompts for chromosome-level multithreading.
2. Add code comments for modcall and multithreading.

### Changes
1. Add code comments
    + HaplotagProcess.cpp
    + ModCallParsingBam.cpp
    + ParsingBam.cpp
    + PhasingProcess.cpp
    + Util.cpp
2. Multithread setting
    + Set the default number of chromosomes to be equal to the number of threads.
3. Output of prompts during the running of phasing
    + Due to multithreading, the prompts in the running output become disordered. Currently, the running time output is modified to be displayed only after each thread has processed its respective contig/chromosome.