### PR TITLE
Modcall output all modification

### DIFF
--- a/ModCall.cpp
+++ b/ModCall.cpp
@@ -17,6 +17,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "optional arguments:\n"
 "      -o, --out-prefix=NAME         prefix of phasing result. default: modcall_result\n"
 "      -t, --threads=Num             number of thread. default:1\n"
+"      --all                         output all coordinates where modifications have been detected.\n"
 
 "phasing arguments:\n"
 "      -m, --modThreshold=[0~1]      value extracted from MM tag and ML tag. \n"
@@ -35,10 +36,11 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 static const char* shortopts = "o:t:r:b:m:u:e:i:";
 
-enum { OPT_HELP = 1 };
+enum { OPT_HELP = 1, ALL_MOD };
 
 static const struct option longopts[] = { 
     { "help",              no_argument,        NULL, OPT_HELP }, 
+    { "all",               no_argument,        NULL, ALL_MOD },
     { "reference",         required_argument,  NULL, 'r' },
     { "out-prefix",        required_argument,  NULL, 'o' },
     { "threads",           required_argument,  NULL, 't' },
@@ -66,6 +68,8 @@ namespace opt
     static float connectConfidence = 0.9;
     
     static std::string command;
+    
+    bool outputAllMod = false;
 }
 
 void ModCallOptions(int argc, char** argv)
@@ -92,6 +96,7 @@ void ModCallOptions(int argc, char** argv)
             arg >> bamFile;
             opt::bamFileVec.push_back(bamFile); break;
         }
+        case ALL_MOD: opt::outputAllMod=true; break;
         case OPT_HELP:
             std::cout << CORRECT_USAGE_MESSAGE;
             exit(EXIT_SUCCESS);
@@ -175,6 +180,8 @@ int ModCallMain(int argc, char** argv, std::string in_version)
     
     ecParams.version=in_version;
     ecParams.command=opt::command;
+    
+    ecParams.outputAllMod=opt::outputAllMod;
     
     ModCallProcess processor(ecParams);
 

--- a/ModCallProcess.h
+++ b/ModCallProcess.h
@@ -18,6 +18,8 @@ struct ModCallParameters
     
     std::string version;
     std::string command;
+    
+    bool outputAllMod;
 };
 
 class ModCallProcess


### PR DESCRIPTION
### Summary
Modcall can output all detected modification positions by using the --all parameter.

### Changes
1. Add code comments
    + ModCallParsingBam.cpp

2. Adjustments to Modcall Output
    + Added the '--all' parameter to output all detected modifications in reads. default false.
    + Homozygous variants only recorded MD, UD, and DP counts. The read names covering the variant will not be recorded.
    + High-confidence heterozygous modifications will be recorded as PASS in the FILTER field.

```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE
chr1    11027   .       C       N       .       .       RS=P;   GT:MD:UD:DP     1/1:5:5:16
chr1    11028   .       G       N       .       .       RS=N;   GT:MD:UD:DP     0/0:4:8:12
chr1    11083   .       G       N       .       .       RS=N;   GT:MD:UD:DP     0/1:4:6:12
chr1    11434   .       C       N       .       PASS    RS=P;MR=eb459876-8c81-4714-a496-a90ea8be94d2,6ca3a71f-62fd-416e-8c6e-8c4a9c054e1a,0d8b7c68-d98d-4045-a572-82fedac62da5,71b5dfe9-7cd1-4959-b634-b9d162468edb,5db6fcd3-5780-494b-bfdd-4d9d7282d012,6e205f04-560a-4975-932d-dbd60ead695d,ae2238f8-b622-4cb5-8f02-4c3f54ab8ca3,d7ef87d0-bffe-404d-9f10-62eceb0c5121;NR=8249c7c7-fd04-4a4c-985d-2bbcb2030bc4,e3b03dc0-8399-4e1e-bd0d-e5e4e3e2911a,b8dc7af8-9f78-4dac-b8cc-35e157c51621,0b2638c1-8380-48b4-b08c-a6161495ad9d,7b1e5c16-f0a6-47f6-9726-247c762a10ca,ac7ae685-082e-413e-b5a6-b4c12d49a1c2,c0e0c526-e193-4ee2-81d6-1fbe0c970dc1;  GT:MD:UD:DP     0/1:8:7:16
```