### PR TITLE
ModCall Multithreading Optimization

### DIFF
--- a/ModCallParsingBam.h
+++ b/ModCallParsingBam.h
@@ -30,15 +30,24 @@ struct MethPosInfo{
     std::vector<std::string> nonModReadVec;
 };
 
+// The ReferenceChromosome struct is used to store information about a reference fasta.
+struct ReferenceChromosome {
+    std::string name;      
+    std::string sequence;  
+    int length;            
+
+    ReferenceChromosome(const std::string& name, const std::string& sequence, int length)
+        : name(name), sequence(sequence), length(length) {}
+};
+
 //FastaParser: to get each chromosome name and lastpos(for chunksize)
 class MethFastaParser{
     private:
         // file name
         std::string fastaFile ;
-        std::vector<std::string> chrName;
-        
+
     public:
-        MethFastaParser(std::string fastaFile, std::map<std::string, std::string> &chrString);
+        MethFastaParser(std::string fastaFile, std::vector<ReferenceChromosome> &chrInfo);
         ~MethFastaParser();
 };
 
@@ -78,12 +87,14 @@ class MethBamParser{
     public:
         MethBamParser(ModCallParameters &params, std::string &refString);
         ~MethBamParser();
-        void detectMeth(std::string chrName, int chr_len, std::vector<ReadVariant> &readVariantVec);
-        void writeResultVCF(std::string chrName, std::map<std::string, std::string> &chrString, bool isFirstChr, std::map<int,int> &passPosition);
+        void detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec);
+        void exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,int> &passPosition, std::ostringstream &methResult);
         void judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &fReadVariantVec, std::vector<ReadVariant> &rReadVariantVec );
         void calculateDepth();
         
 };
+
+void writeResultVCF(ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo, std::map<std::string,std::ostringstream> &chrResult);
 
 class MethylationGraph{
     private:

--- a/ModCallProcess.cpp
+++ b/ModCallProcess.cpp
@@ -6,41 +6,50 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
     // parsing ref fasta
     std::time_t begin= time(NULL);
     std::cerr<< "reading reference ... ";
-    std::map<std::string, std::string> chrString;
-    MethFastaParser MethFastaParser(params.fastaFile, chrString);
+    std::vector<ReferenceChromosome> chrInfo;
+    MethFastaParser MethFastaParser(params.fastaFile, chrInfo);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
+    
+    // record all ModCall result
+    std::map<std::string,std::ostringstream> chrModCallResult;
+    // Initialize an empty map in chrModCallResult to store all ModCall results.
+    // This is done to prevent issues with multi-threading, by defining an empty map first.
+    for (auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); chrIter++) {
+        chrModCallResult[chrIter->name] = std::ostringstream();
+    }
 
-    bool isFirstchr = true;
+    // set chrNumThreads and bamParserNumThreads based on parameters
+    int chrNumThreads,bamParserNumThreads;
+    setModcallNumThreads(params.numThreads, chrNumThreads, bamParserNumThreads);
+    // setNumThreads(chrInfo.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
+    begin = time(NULL);
+
     //loop all chromosomes
-    for(auto chrIter = chrString.begin(); chrIter != chrString.end(); chrIter++){
-        
+    #pragma omp parallel for schedule(dynamic) num_threads(chrNumThreads)
+    for(auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); ++chrIter) {
+        std::time_t chrbegin = time(NULL);
+
         // store variant
         std::vector<ReadVariant> fReadVariantVec;
         std::vector<ReadVariant> rReadVariantVec;
         std::vector<ReadVariant> readVariantVec;
         // record hetero metyhl position
         std::map<int,int> *passPosition = new std::map<int,int>;
+
+        std::string chrName = chrIter->name;
+        std::string chrSeq = chrIter->sequence;
+        int chrLen = chrIter->length;
         
-        begin = time(NULL);
-        std::string chrName = (*chrIter).first;
-        int chrLen = (*chrIter).second.length();
+        MethBamParser *methbamparser = new MethBamParser(params, chrSeq);
         
-        std::cerr<<"parsing contig/chromosome: "<<chrName<<" ... ";
-        MethBamParser *methbamparser = new MethBamParser(params, (*chrIter).second);
-        
-        std::cerr<<"parsing Bam " << " ... ";
-        methbamparser->detectMeth(chrName, chrLen, readVariantVec);
+        methbamparser->detectMeth(chrName, chrLen, bamParserNumThreads, readVariantVec);
 
         //new new calculate depth
-        std::cerr<<"cal depth " << " ... ";
         methbamparser->calculateDepth();
         
         //judge methylation genotype
-        std::cerr<<"judge meth " << " ... ";
         methbamparser->judgeMethGenotype(chrName, readVariantVec, fReadVariantVec, rReadVariantVec);
-        
-        std::cerr<< "run algorithm ... ";
-        
+
         MethylationGraph *fGraph = new MethylationGraph(params);
         MethylationGraph *rGraph = new MethylationGraph(params);
         fGraph->addEdge(fReadVariantVec);
@@ -53,13 +62,9 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         rGraph->destroy();
         delete fGraph;
         delete rGraph;
-
         
-        //write to vcf file
-        std::cerr<<"write vcf " << " ... ";
-        methbamparser->writeResultVCF(chrName, chrString, isFirstchr, (*passPosition));
-        isFirstchr = false;
-        std::cerr<< difftime(time(NULL), begin) << "s\n";
+        //push result to ModCallResult
+        methbamparser->exportResult(chrName, chrSeq, chrLen, (*passPosition), chrModCallResult[chrName]);
         
         passPosition->clear();
         
@@ -72,7 +77,16 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         fReadVariantVec.shrink_to_fit();
         rReadVariantVec.clear();
         rReadVariantVec.shrink_to_fit();
+
+        std::cerr<< "(" << chrName << "," << difftime(time(NULL), chrbegin) << "s)";
     }
+    std::cerr<< "\nmodcall total:  " << difftime(time(NULL), begin) << "s\n";
+
+    begin= time(NULL);
+    std::cerr<<"write vcf " << " ... ";
+    //write to vcf file
+    writeResultVCF(params, chrInfo, chrModCallResult);
+    std::cerr<< difftime(time(NULL), begin) << "s\n";
 }
 
 ModCallProcess::~ModCallProcess(){

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -45,7 +45,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     
     // set chrNumThreads and bamParserNumThreads based on parameters
     int chrNumThreads,bamParserNumThreads;
-    setNumThreads(chrName.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
+    setPhasingNumThreads(chrName.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
     begin = time(NULL);
     
     // loop all chromosome

--- a/Util.h
+++ b/Util.h
@@ -38,14 +38,18 @@ void mergeAllChrPhasingResult(const ChrPhasingResult& allChrPhasingResults, Phas
  * @param availableThreads  Total threads available for processing
  * @param chrnumThreads Set to the number of threads for chromosome processing.
  * @param bamParsernumThreads Set to the number of threads for BAM parsing.
- *
- * Depending on availableThreads, this function adjusts chrnumThreads and bamParsernumThreads 
- * for optimized parallel processing. The thread allocation strategy changes based on 
- * whether availableThreads is less than or equal to 24, between 25 and 48, or greater than 48.
- * This function's thread allocation strategy is designed considering the typical count 
- * of human chromosomes.
  */
-void setNumThreads(const int& defaultChrThreads,const int& availableThreads,  int& chrnumThreads, int& bamParsernumThreads);
+void setPhasingNumThreads(const int& defaultChrThreads,const int& availableThreads,  int& chrnumThreads, int& bamParsernumThreads);
+
+/**
+ * Configures thread counts for chromosome processing and BAM parsing.
+ *
+ * @param availableThreads  Total threads available for processing
+ * @param chrnumThreads Set to the number of threads for chromosome processing.
+ * @param bamParsernumThreads Set to the number of threads for BAM parsing.
+ */
+void setModcallNumThreads(const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads);
+
 
 // use for parsing
 struct Variant{


### PR DESCRIPTION
### Summary
Optimized modcall runtime and ensured multithread safety.

### Changes
1. MethFastaParser Utilizing New Structure:
    * Revised the storage structure of references fasta to include chromosome length information, facilitating chromosome processing in the correct numerical order (chr1, chr2, chr3) instead of lexicographical order (chr1, chr11, chr12). 
    * This change not only eliminates the need to recalculate chromosome lengths but also enhances execution efficiency in a multithreaded environment.
2. Modifications  in MethBamParser:
    * Introduced an additional parameter int numThreads in the function detectMeth. This change allows for dynamic allocation of threads based on the processing requirements, improving the handling of multi-threaded operations.
3. Thread Safety Measures:
    * Split the writeResultVCF function into two parts: exportResult and writeResultVCF.
    * exportResult: Handles the processing results for each chromosome, preparing data for VCF file writing.
    * writeResultVCF: Tasked with the actual writing of data into the VCF file, ensuring the integrity and sequentiality of output.
4. Changes in ModCallProcess:
    * New Function - setModcallNumThreads :Implemented to intelligently allocate threads between chromosome processing and BAM parsing tasks.

### Testing
This test compares the run times with the develop branch (commit f46509bba8bcb27e9812fbc3aacb6738f351df75), performing modcall at 10x to 60x scale using 20 threads. The time format is `mm:ss`.

| Test Condition | Run Time Before Optimization | Maximum Memory Before Optimization (GB) | Run Time After Optimization | Maximum Memory After Optimization (GB) |
|----------------|------------------------------|----------------------------------------|-----------------------------|----------------------------------------|
| HG002 ONT 10x  | 05:02.2                      | 11.3                                   | 01:21.1                     | 26.1                                   |
| HG002 ONT 20x  | 09:21.7                      | 15.3                                   | 03:16.8                     | 39.7                                   |
| HG002 ONT 30x  | 11:18.1                      | 18.9                                   | 02:56.3                     | 52.6                                   |
| HG002 ONT 40x  | 20:05.3                      | 22.6                                   | 05:32.6                     | 65.6                                   |
| HG002 ONT 50x  | 23:54.2                      | 26.2                                   | 06:12.8                     | 78.3                                   |
| HG002 ONT 60x  | 21:51.5                      | 29.8                                   | 05:37.6                     | 91.1                                   |

