### PR TITLE
haplotag supports phased indels and modification VCF.

### DIFF
--- a/Haplotag.cpp
+++ b/Haplotag.cpp
@@ -16,6 +16,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "optional arguments:\n"
 "      --tagSupplementary              tag supplementary alignment. default:false\n"
 "      --sv-file=NAME                  input phased SV vcf file.\n"
+"      --mod-file=NAME                 input a modified VCF file (produced by longphase modcall and processed by longphase phase).\n"
 "      -q, --qualityThreshold=Num      not tag alignment if the mapping quality less than threshold. default:0\n"
 "      -p, --percentageThreshold=Num   the alignment will be tagged according to the haplotype corresponding to most alleles.\n"
 "                                      if the alignment has no obvious corresponding haplotype, it will not be tagged. default:0.6\n"
@@ -26,7 +27,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 static const char* shortopts = "s:b:o:t:q:p:r:";
 
-enum { OPT_HELP = 1, TAG_SUP, SV_FILE, LOG};
+enum { OPT_HELP = 1, TAG_SUP, SV_FILE, LOG, MOD_FILE};
 
 static const struct option longopts[] = { 
     { "help",                 no_argument,        NULL, OPT_HELP },
@@ -35,6 +36,7 @@ static const struct option longopts[] = {
     { "reference",            required_argument,  NULL, 'r' },
     { "tagSupplementary",     no_argument,        NULL, TAG_SUP },
     { "sv-file",              required_argument,  NULL, SV_FILE },
+    { "mod-file",             required_argument,  NULL, MOD_FILE },
     { "out-prefix",           required_argument,  NULL, 'o' },
     { "threads",              required_argument,  NULL, 't' },
     { "qualityThreshold",     required_argument,  NULL, 'q' },
@@ -50,6 +52,7 @@ namespace opt
     static double percentageThreshold = 0.6;
     static std::string snpFile="";
     static std::string svFile="";
+    static std::string modFile="";
     static std::string bamFile="";
     static std::string fastaFile="";
     static std::string resultPrefix="result";
@@ -75,6 +78,7 @@ void HaplotagOptions(int argc, char** argv)
         case 'q': arg >> opt::qualityThreshold; break;
         case 'p': arg >> opt::percentageThreshold; break;
         case SV_FILE: arg >> opt::svFile; break;
+        case MOD_FILE: arg >> opt::modFile; break;
         case TAG_SUP: opt::tagSupplementary = true; break;
         case LOG: opt::writeReadLog = true; break;
         case OPT_HELP:
@@ -109,6 +113,16 @@ void HaplotagOptions(int argc, char** argv)
         if( !openFile.is_open() )
         {
             std::cerr<< "File " << opt::svFile << " not exist.\n\n";
+            die = true;
+        }
+    }
+    
+    if( opt::modFile != "")
+    {
+        std::ifstream openFile( opt::modFile.c_str() );
+        if( !openFile.is_open() )
+        {
+            std::cerr<< "File " << opt::modFile << " not exist.\n\n";
             die = true;
         }
     }
@@ -173,6 +187,7 @@ int HaplotagMain(int argc, char** argv)
     ecParams.qualityThreshold=opt::qualityThreshold;
     ecParams.snpFile=opt::snpFile;
     ecParams.svFile=opt::svFile;
+    ecParams.modFile=opt::modFile;
     ecParams.bamFile=opt::bamFile;
     ecParams.fastaFile=opt::fastaFile;
     ecParams.resultPrefix=opt::resultPrefix;

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -276,6 +276,21 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
         exit(1);
     }
 
+    // record reference last variant pos
+    std::vector<int> last_pos;
+    for( auto chr : chrVec ){
+        auto lastVariantIter = chrVariantPS[chr].rbegin();
+        if( lastVariantIter != chrVariantPS[chr].rend() ){
+            last_pos.push_back(lastVariantIter->second);
+        }
+        else{
+            last_pos.push_back(0);
+        }
+    }
+
+    // reference fasta parser
+    FastaParser fastaParser(params.fastaFile , chrVec, last_pos);
+
     // write tag read detail information
     std::ofstream *tagResult=NULL;
     if(params.writeReadLog){
@@ -324,21 +339,29 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
     for(auto chr : chrVec ){
         std::time_t begin = time(NULL);
         std::cerr<<"chr: " << chr << " ... " ;
-
-        currentVariants = chrVariant[chr];
-        firstVariantIter = currentVariants.begin();
-
-        std::map<int, RefAlt>::reverse_iterator last = currentVariants.rbegin();
-
+        // records all variants within this chromosome.
+        currentChrVariants = chrVariant[chr];
+        // since each read is sorted based on the start coordinates, to save time, 
+        // firstVariantIter keeps track of the first variant that each read needs to check.
+        firstVariantIter = currentChrVariants.begin();
+        // get the coordinates of the last variant
+        // the tagging process will not be perform if the read's start coordinate are over than last variant.
+        std::map<int, RefAlt>::reverse_iterator last = currentChrVariants.rbegin();
+        
+        // fetch chromosome string
+        std::string chr_reference = fastaParser.chrString.at(chr);
+        
+        // tagging will be attempted for reads within the specified coordinate range.
         std::string range = chr + ":1-" + std::to_string(chrLength[chr]);
         hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
-
+        // iter all reads
         while ((result = sam_itr_multi_next(in, iter, aln)) >= 0) {
             totalAlignment++;
             int flag = aln->core.flag;
 
             if ( aln->core.qual < params.qualityThreshold ){
                 // mapping quality is lower than threshold
+                // write this alignment to result bam file
                 result = sam_write1(out, bamHdr, aln);
                 continue;
             }
@@ -346,6 +369,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
             if( (flag & 0x4) != 0 ){
                 // read unmapped
                 totalUnmapped++;
+                // write this alignment to result bam file
                 result = sam_write1(out, bamHdr, aln);
                 continue;
             }
@@ -353,6 +377,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
                 // secondary alignment. repeat.
                 // A secondary alignment occurs when a given read could align reasonably well to more than one place.
                 totalSecondary++;
+                // write this alignment to result bam file
                 result = sam_write1(out, bamHdr, aln);
                 continue;
             }
@@ -360,16 +385,18 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
                 // supplementary alignment
                 // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
                 totalSupplementary++;
+                // write this alignment to result bam file
                 result = sam_write1(out, bamHdr, aln);
                 continue;
             }
 
-            if(last == currentVariants.rend()){
+            if(last == currentChrVariants.rend()){
+                // skip 
                 totalUnTagCuonnt++;
             }
             else if(int(aln->core.pos) <= (*last).first){
                 int pqValue = 0;
-                int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue);
+                int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue, chr_reference);
 
                 initFlag(aln, "HP");
                 initFlag(aln, "PS");
@@ -387,6 +414,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
                     totalUnTagCuonnt++;
                 }
             }
+            // write this alignment to result bam file
             result = sam_write1(out, bamHdr, aln);
         }
         std::cerr<< difftime(time(NULL), begin) << "s\n";
@@ -411,7 +439,7 @@ void HaplotagProcess::initFlag(bam1_t *aln, std::string flag){
     return;
 }
 
-int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue){
+int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue, const std::string &ref_string){
 
     int hp1Count = 0;
     int hp2Count = 0;
@@ -420,11 +448,13 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
     std::map<int,int> countPS;
 
     // Skip variants that are to the left of this read
-    while( firstVariantIter != currentVariants.end() && (*firstVariantIter).first < aln.core.pos )
+    while( firstVariantIter != currentChrVariants.end() && (*firstVariantIter).first < aln.core.pos ){
         firstVariantIter++;
-
-    if( firstVariantIter == currentVariants.end() )
+    }
+    
+    if( firstVariantIter == currentChrVariants.end() ){
         return 0;
+    }
 
     // position relative to reference
     int ref_pos = aln.core.pos;
@@ -441,7 +471,7 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
         int length   = bam_cigar_oplen(cigar[i]);
 
         // iterator next variant
-        while( currentVariantIter != currentVariants.end() && (*currentVariantIter).first < ref_pos ){
+        while( currentVariantIter != currentChrVariants.end() && (*currentVariantIter).first < ref_pos ){
             currentVariantIter++;
         }
 
@@ -451,8 +481,10 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
         // 8: sequence mismatch
         if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
 
-            while( currentVariantIter != currentVariants.end() && (*currentVariantIter).first < ref_pos + length){
+            while( currentVariantIter != currentChrVariants.end() && (*currentVariantIter).first < ref_pos + length){
 
+                int refAlleleLen = (*currentVariantIter).second.Ref.length();
+                int altAlleleLen = (*currentVariantIter).second.Alt.length();
                 int offset = (*currentVariantIter).first - ref_pos;
 
                 if( offset < 0){
@@ -461,29 +493,99 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
                     uint8_t *q = bam_get_seq(&aln);
                     char base_chr = seq_nt16_str[bam_seqi(q,query_pos + offset)];
                     std::string base(1, base_chr);
-                    // base match SNP allele
-                    if( (base == (*currentVariantIter).second.Ref) || (base == (*currentVariantIter).second.Alt) ){
+                    
+                    // currentVariant is SNP
+                    if( refAlleleLen == 1 && altAlleleLen == 1 ){
+                        // Detected that the base of the read is either REF or ALT. 
+                        if( (base == (*currentVariantIter).second.Ref) || (base == (*currentVariantIter).second.Alt) ){
 
-                        std::map<int, int>::iterator posPSiter = chrVariantPS[chrName].find((*currentVariantIter).first);
+                            std::map<int, int>::iterator posPSiter = chrVariantPS[chrName].find((*currentVariantIter).first);
 
-                        if( posPSiter == chrVariantPS[chrName].end() ){
-                            std::cerr<< (*currentVariantIter).first << "\t"
-                                     << (*currentVariantIter).second.Ref << "\t"
-                                     << (*currentVariantIter).second.Alt << "\n";
-                            exit(EXIT_SUCCESS);
+                            if( posPSiter == chrVariantPS[chrName].end() ){
+                                std::cerr<< (*currentVariantIter).first << "\t"
+                                         << (*currentVariantIter).second.Ref << "\t"
+                                         << (*currentVariantIter).second.Alt << "\n";
+                                exit(EXIT_SUCCESS);
+                            }
+                            else{
+                                if( base == chrVariantHP1[chrName][(*currentVariantIter).first]){
+                                    hp1Count++;
+                                    variantsHP[(*currentVariantIter).first]=0;
+                                }
+                                if( base == chrVariantHP2[chrName][(*currentVariantIter).first]){
+                                    hp2Count++;
+                                    variantsHP[(*currentVariantIter).first]=1;
+                                }
+                                countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
+                            }
+                            
                         }
-                        else{
-                            if( base == chrVariantHP1[chrName][(*currentVariantIter).first]){
+                    }
+                    // currentVariant is insertion
+                    else if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
+                        
+                        int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
+                        int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
+                        
+                        if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 1 ) {
+                            // hp1 occur insertion
+                            if( hp1Length != 1 && hp2Length == 1 ){
                                 hp1Count++;
                                 variantsHP[(*currentVariantIter).first]=0;
                             }
-                            if(base == chrVariantHP2[chrName][(*currentVariantIter).first]){
+                            // hp2 occur insertion
+                            else if( hp1Length == 1 && hp2Length != 1 ){
                                 hp2Count++;
                                 variantsHP[(*currentVariantIter).first]=1;
                             }
-                            countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
                         }
-                    }
+                        else {
+                            // hp1 occur insertion
+                            if( hp1Length != 1 && hp2Length == 1 ){
+                                hp2Count++;
+                                variantsHP[(*currentVariantIter).first]=1;
+                            }
+                            // hp2 occur insertion
+                            else if( hp1Length == 1 && hp2Length != 1 ){
+                                hp1Count++;
+                                variantsHP[(*currentVariantIter).first]=0;
+                            }
+                        }
+                        countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
+                    } 
+                    // currentVariant is deletion
+                    else if( refAlleleLen != 1 && altAlleleLen == 1 && i+1 < aln_core_n_cigar) {
+                        
+                        int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
+                        int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
+                        
+                        if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 2 ) {
+                            // hp1 occur deletion
+                            if( hp1Length != 1 && hp2Length == 1 ){
+                                hp1Count++;
+                                variantsHP[(*currentVariantIter).first]=0;
+                            }
+                            // hp2 occur deletion
+                            else if( hp1Length == 1 && hp2Length != 1 ){
+                                hp2Count++;
+                                variantsHP[(*currentVariantIter).first]=1;
+                            }
+                        }
+                        else {
+                            // hp2 occur deletion
+                            if( hp1Length != 1 && hp2Length == 1 ){
+                                hp2Count++;
+                                variantsHP[(*currentVariantIter).first]=1;
+                            }
+                            // hp1 occur deletion
+                            else if( hp1Length == 1 && hp2Length != 1 ){
+                                hp1Count++;
+                                variantsHP[(*currentVariantIter).first]=0;
+                            }
+                        }
+                        countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
+                    } 
+
                 }
                 currentVariantIter++;
             }
@@ -496,6 +598,58 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
         }
             // 2: deletion from the reference
         else if( cigar_op == 2 ){
+            
+            if(ref_string != ""){
+                int del_len = length;
+                if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
+                    //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
+                        // special case
+                    //}
+                }
+                else if( (*currentVariantIter).first >= ref_pos  && (*currentVariantIter).first < ref_pos + del_len ){
+                    // check variant in homopolymer
+                    if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
+                        
+                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
+                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
+                        
+                        // SNP
+                        if( refAlleleLen == 1 && altAlleleLen == 1){
+                            // get the next match
+                            char base_chr = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
+                            std::string base(1, base_chr);
+
+                            if( base == chrVariantHP1[chrName][(*currentVariantIter).first]){
+                                hp1Count++;
+                                variantsHP[(*currentVariantIter).first]=0;
+                            }
+                            if( base == chrVariantHP2[chrName][(*currentVariantIter).first]){
+                                hp2Count++;
+                                variantsHP[(*currentVariantIter).first]=1;
+                            }
+                            countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
+                        }
+                        
+                        // the read deletion contain VCF's deletion
+                        else if( refAlleleLen != 1 && altAlleleLen == 1){
+
+                            int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
+                            int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
+                            // hp1 occur deletion
+                            if( hp1Length != 1 && hp2Length == 1 ){
+                                hp1Count++;
+                                variantsHP[(*currentVariantIter).first]=0;
+                            }
+                            // hp2 occur deletion
+                            else if( hp1Length == 1 && hp2Length != 1 ){
+                                hp2Count++;
+                                variantsHP[(*currentVariantIter).first]=1;
+                            }
+                            countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
+                        }
+                    }
+                }
+            }
             ref_pos += length;
         }
             // 3: skipped region from the reference

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -43,14 +43,14 @@ class HaplotagProcess
     std::map<std::string, std::map<int, std::string> > chrVariantHP1;
     std::map<std::string, std::map<int, std::string> > chrVariantHP2;
 
-    std::map<int, RefAlt> currentVariants;
+    std::map<int, RefAlt> currentChrVariants;
     std::map<int, RefAlt>::iterator firstVariantIter;
     // The number of SVs occurring on different haplotypes in a read
     std::map<std::string, std::map<int, int> > readSVHapCount;
 
     void initFlag(bam1_t *aln, std::string flag);
     
-    int judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue);
+    int judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue, const std::string &ref_string);
     
     int totalAlignment;
     int totalSupplementary;

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -14,6 +14,7 @@ struct HaplotagParameters
     
     std::string snpFile;
     std::string svFile;
+    std::string modFile;
     std::string bamFile;
     std::string fastaFile;
     std::string resultPrefix;
@@ -61,7 +62,9 @@ class HaplotagProcess
     
     std::time_t processBegin;
     bool integerPS;
+    bool parseSnpFile;
     bool parseSVFile;
+    bool parseMODFile;
     
     public:
         HaplotagProcess(HaplotagParameters params);

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -972,7 +972,7 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
     
 }
 
-void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec,const std::string &ref_string, bool isONT){
+void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string, bool isONT){
 
     ReadVariant *tmpReadResult = new ReadVariant();
     (*tmpReadResult).read_name = bam_get_qname(&aln);
@@ -1148,7 +1148,7 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
             // it will determine whether the SNP falls in the homopolymer
             // and start the processing of the SNP fall in the alignment GAP
             
-            if(ref_string != "" && isONT){
+            if(ref_string != ""){
                 int del_len = length;
                 if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
                     //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
@@ -1172,28 +1172,32 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                         if( refAlleleLen == 1 && altAlleleLen == 1){
                             // get the next match
                             char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
-                            if( base == (*currentVariantIter).second.Ref[0] )
+                            if( base == (*currentVariantIter).second.Ref[0] ){
                                 allele = 0;
-                            else if( base == (*currentVariantIter).second.Alt[0] )
+                            }
+                            else if( base == (*currentVariantIter).second.Alt[0] ){
                                 allele = 1;
-                            
+                            }
                             base_q = bam_get_qual(&aln)[query_pos];
                         }
-                        
                         // the read deletion contain VCF's deletion
-                        if( refAlleleLen != 1 && altAlleleLen == 1){
-                            //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
-                            //std::string refSeq = (*currentVariantIter).second.Ref;
-                            //std::string altSeq = (*currentVariantIter).second.Alt;
+                        else if( refAlleleLen != 1 && altAlleleLen == 1 ){
 
-                            allele = 1;
-                            // using this quality to identify indel
-                            base_q = -4;
-                        }
-                        else if ( allele == -1 ) {
-                            allele = 0;
-                            // using this quality to identify indel
-                            base_q = -4;
+                            if( refAlleleLen != 1 && altAlleleLen == 1){
+                                //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
+                                //std::string refSeq = (*currentVariantIter).second.Ref;
+                                //std::string altSeq = (*currentVariantIter).second.Alt;
+
+                                allele = 1;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            else if ( allele == -1 ) {
+                                allele = 0;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            
                         }
                         
                         if(allele != -1){
@@ -1202,7 +1206,7 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                             currentVariantIter++;
                             delete tmpVariant;
                         }
-                        
+
                     }
                 }
             }

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -97,7 +97,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
         // use to store variant
         std::vector<ReadVariant> readVariantVec;
         // run fetch variant process
-        bamParser->direct_detect_alleles(lastSNPpos, bamParserNumThreads, params, readVariantVec ,chr_reference);
+        bamParser->direct_detect_alleles(lastSNPpos, bamParserNumThreads, params, readVariantVec , chr_reference);
         // free memory
         delete bamParser;
         

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 
 
 #define PROGRAM_BIN "main"
-#define VERSION "1.6"
+#define VERSION "1.6.1dev"
 
 static std::string version = VERSION;
 


### PR DESCRIPTION
### Changes
1. When utilizing `haplotag` for read haplotype tagging, it will automatically detect whether the phased SNP file includes phased indels.
2. When performing read haplotype tagging with `haplotag`, it can use the `--mod-file` option to input the phased modification VCF.
3. Correcting the condition in ParsingBam.cpp for determining when a deletion variant that fall within the read's deletion cigar.