### PR TITLE
Solve the problem where other variants with the same coordinates are also changed after a variant is phased

### DIFF
--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -468,7 +468,7 @@ void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resul
         auto posIter = (*chrVariant)[fields[0]].find(posIdx);
         
         // this pos is phase
-        if( psElementIter != phasingResult.end() /*&& posIter != (*chrVariant)[fields[0]].end()*/ ){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
             fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
@@ -837,7 +837,7 @@ void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &result
         auto posIter = (*chrVariant)[fields[0]].find(posIdx);
         
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() /*&& posIter != (*chrVariant)[fields[0]].end()*/ ){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
@@ -1491,7 +1491,7 @@ void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resu
         auto posIter = (*chrVariant)[fields[0]].find(posIdx); 
         
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end()/* && posIter != (*chrVariant)[fields[0]].end() */){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -464,8 +464,11 @@ void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resul
             }   
         }
 
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+        
         // this pos is phase
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end() /*&& posIter != (*chrVariant)[fields[0]].end()*/ ){
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
             fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
@@ -829,9 +832,12 @@ void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &result
                 fields[9][modify_start+1] = '/';
             }        
         }
-                
+        
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+        
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end() /*&& posIter != (*chrVariant)[fields[0]].end()*/ ){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
@@ -1480,9 +1486,12 @@ void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resu
                 fields[9][modify_start+1] = '/';
             }        
         }
-                
+        
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx); 
+        
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end()/* && posIter != (*chrVariant)[fields[0]].end() */){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";


### PR DESCRIPTION
### Changes
The variants used in multiple VCFs will be accessed and stored in their respective `chrVariant`, even if multiple variants occur at the same coordinate, only one `chrVariant `from one VCF will be recorded.