### PR TITLE
make the baseQuality and edgeWeight modified parameters for users

### DIFF
--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -536,10 +536,10 @@ void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
 
                 // this allele support ref
                 if( (*variant1Iter).allele == 0 )
-                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,0,1);
                 // this allele support alt
                 if( (*variant1Iter).allele == 1 )
-                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,0,1);
                 
                 // next snp
                 variant2Iter++;

--- a/Phasing.cpp
+++ b/Phasing.cpp
@@ -28,6 +28,8 @@ static const char *CORRECT_USAGE_MESSAGE =
 "   -q, --mappingQuality=Num               filter alignment if mapping quality is lower than threshold. default:1\n\n"
 
 "phasing graph arguments:\n"
+"   -p, --baseQuality=[0~90]               change edge's weight to --edgeWeight if base quality is lower than the threshold. default:12\n"
+"   -e, --edgeWeight=[0~1]                 decide how much weight should we change if it has low base quality. default:0.1\n"
 "   -a, --connectAdjacent=Num              connect adjacent N SNPs. default:20\n"
 "   -d, --distance=Num                     phasing two variant if distance less than threshold. default:300000\n"
 "   -1, --edgeThreshold=[0~1]              give up SNP-SNP phasing pair if the number of reads of the \n"
@@ -39,7 +41,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 "\n";
 
-static const char* shortopts = "s:b:o:t:r:d:1:a:q:n:m:";
+static const char* shortopts = "s:b:o:t:r:d:1:a:q:p:e:n:m:";
 
 enum { OPT_HELP = 1 , DOT_FILE, SV_FILE, MOD_FILE, IS_ONT, IS_PB, PHASE_INDEL, VERSION};
 
@@ -61,6 +63,8 @@ static const struct option longopts[] = {
     { "edgeThreshold",        required_argument,  NULL, '1' },
     { "connectAdjacent",      required_argument,  NULL, 'a' },
     { "mappingQuality",       required_argument,  NULL, 'q' },
+    { "baseQuality",       required_argument,  NULL, 'p' },
+    { "edgeWeight",       required_argument,  NULL, 'e' },
     { "snpConfidence",        required_argument,  NULL, 'n' },
     { "readConfidence",       required_argument,  NULL, 'm' },
     { NULL, 0, NULL, 0 }
@@ -82,7 +86,10 @@ namespace opt
     static bool phaseIndel=false;
     
     static int connectAdjacent = 20;
-    static int mappingQuality =1;
+    static int mappingQuality = 1;
+
+    static int baseQuality = 12;
+    static double edgeWeight = 0.1 ;
 
     static double snpConfidence  = 0.75;
     static double readConfidence = 0.65;
@@ -110,6 +117,8 @@ void PhasingOptions(int argc, char** argv)
         case '1': arg >> opt::edgeThreshold; break; 
         case 'a': arg >> opt::connectAdjacent; break;
         case 'q': arg >> opt::mappingQuality; break;
+	case 'p': arg >> opt::baseQuality; break;
+	case 'e': arg >> opt::edgeWeight; break;
         case 'n': arg >> opt::snpConfidence; break;
         case 'm': arg >> opt::readConfidence; break;
         case 'b': {
@@ -207,6 +216,20 @@ void PhasingOptions(int argc, char** argv)
         die = true;
     }
 
+    if ( opt::baseQuality < 0 ){
+        std::cerr << SUBPROGRAM " invalid baseQuality. value: "
+                  << opt::baseQuality
+                  << "\n please check -m, --mappingQuality=[0~90]\n";
+        die = true;
+    }
+
+    if ( opt::edgeWeight < 0 ){
+        std::cerr << SUBPROGRAM " invalid edgeWeight. value: "
+                  << opt::edgeWeight
+                  << "\n please check -m, --edgeWeight=[0~1]\n";
+        die = true;
+    }
+
     if ( opt::edgeThreshold < 0 || opt::edgeThreshold > 1 ){
         std::cerr << SUBPROGRAM " invalid edgeThreshold. value: " 
                   << opt::edgeThreshold 
@@ -258,6 +281,9 @@ int PhasingMain(int argc, char** argv, std::string in_version)
     
     ecParams.connectAdjacent=opt::connectAdjacent;
     ecParams.mappingQuality=opt::mappingQuality;
+
+    ecParams.baseQuality=opt::baseQuality;
+    ecParams.edgeWeight=opt::edgeWeight;
 
     ecParams.edgeThreshold=opt::edgeThreshold;
     

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -23,7 +23,7 @@ void SubEdge::destroy(){
     delete altReadCount;
 }
 
-void SubEdge::addSubEdge(int currentQuality, Variant connectNode, std::string readName){
+void SubEdge::addSubEdge(int currentQuality, Variant connectNode, std::string readName, int baseQuality, double edgeWeight){
     // target noded is REF allele
     if(connectNode.allele == 0 ){
         // debug, this parameter will record the names of all reads between two points
@@ -36,10 +36,10 @@ void SubEdge::addSubEdge(int currentQuality, Variant connectNode, std::string re
         else{
             (*refQuality)[connectNode.position] += currentQuality + connectNode.quality;
         }*/
-	if ( currentQuality >= 12 && connectNode.quality >= 12 )
+	if ( currentQuality >= baseQuality && connectNode.quality >= baseQuality )
             (*refReadCount)[connectNode.position]++;
         else {
-            (*refReadCount)[connectNode.position] = (*refReadCount)[connectNode.position] + 0.1 ;
+            (*refReadCount)[connectNode.position] = (*refReadCount)[connectNode.position] + edgeWeight ;
         }
 	//(*refReadCount)[connectNode.position]++;
     }
@@ -55,10 +55,10 @@ void SubEdge::addSubEdge(int currentQuality, Variant connectNode, std::string re
         else{
             (*altQuality)[connectNode.position] += currentQuality + connectNode.quality;
         }*/
-	if ( currentQuality >= 12 && connectNode.quality >= 12 )
+	if ( currentQuality >= baseQuality && connectNode.quality >= baseQuality )
             (*altReadCount)[connectNode.position]++;
         else {
-            (*altReadCount)[connectNode.position] = (*altReadCount)[connectNode.position] + 0.1 ;
+            (*altReadCount)[connectNode.position] = (*altReadCount)[connectNode.position] + edgeWeight ;
         }
 	//(*altReadCount)[connectNode.position]++;
     }
@@ -477,10 +477,10 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
             for(int nextNode = 0 ; nextNode < params->connectAdjacent; nextNode++){
                 // this allele support ref
                 if( (*variant1Iter).allele == 0 )
-                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,params->baseQuality,params->edgeWeight);
                 // this allele support alt
                 if( (*variant1Iter).allele == 1 )
-                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,params->baseQuality,params->edgeWeight);
                 
                 // next snp
                 variant2Iter++;

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -32,7 +32,7 @@ class SubEdge{
         
         void destroy();
         
-        void addSubEdge(int currentQuality, Variant connectNode, std::string readName);
+        void addSubEdge(int currentQuality, Variant connectNode, std::string readName, int baseQuality, double edgeWeight);
         std::pair<float,float> BestPair(int targetPos);
         float getRefReadCount(int targetPos);
         float getAltReadCount(int targetPos);        

--- a/PhasingProcess.h
+++ b/PhasingProcess.h
@@ -22,6 +22,9 @@ struct PhasingParameters
     int connectAdjacent;
     int mappingQuality;
 
+    int baseQuality;
+    double edgeWeight;
+
     double snpConfidence;
     double readConfidence;
     


### PR DESCRIPTION
Add two parameters "baseQuality" and "edgeWeight" guide to the --help list.
Users can now decide what baseQuality threshold and edgeWeight they want to use.