### PR TITLE
Multithread chromosome

### DIFF
--- a/Haplotag.cpp
+++ b/Haplotag.cpp
@@ -22,12 +22,13 @@ static const char *CORRECT_USAGE_MESSAGE =
 "                                      if the alignment has no obvious corresponding haplotype, it will not be tagged. default:0.6\n"
 "      -t, --threads=Num               number of thread. default:1\n"
 "      -o, --out-prefix=NAME           prefix of phasing result. default:result\n"
+"      --region=REGION                 tagging include only reads/variants overlapping those regions. default:""(all regions)"
 "      --log                           an additional log file records the result of each read. default:false\n";
 
 
 static const char* shortopts = "s:b:o:t:q:p:r:";
 
-enum { OPT_HELP = 1, TAG_SUP, SV_FILE, LOG, MOD_FILE};
+enum { OPT_HELP = 1, TAG_SUP, SV_FILE, REGION, LOG, MOD_FILE};
 
 static const struct option longopts[] = { 
     { "help",                 no_argument,        NULL, OPT_HELP },
@@ -41,6 +42,7 @@ static const struct option longopts[] = {
     { "threads",              required_argument,  NULL, 't' },
     { "qualityThreshold",     required_argument,  NULL, 'q' },
     { "percentageThreshold",  required_argument,  NULL, 'p' },
+    { "region",               required_argument,  NULL, REGION },
     { "log",                  no_argument,        NULL, LOG },
     { NULL, 0, NULL, 0 }
 };
@@ -56,6 +58,7 @@ namespace opt
     static std::string bamFile="";
     static std::string fastaFile="";
     static std::string resultPrefix="result";
+    static std::string region="";
     static bool tagSupplementary = false;
     static bool writeReadLog = false;
 }
@@ -80,6 +83,7 @@ void HaplotagOptions(int argc, char** argv)
         case SV_FILE: arg >> opt::svFile; break;
         case MOD_FILE: arg >> opt::modFile; break;
         case TAG_SUP: opt::tagSupplementary = true; break;
+        case REGION: arg >> opt::region; break;
         case LOG: opt::writeReadLog = true; break;
         case OPT_HELP:
             std::cout << CORRECT_USAGE_MESSAGE;
@@ -193,6 +197,7 @@ int HaplotagMain(int argc, char** argv)
     ecParams.resultPrefix=opt::resultPrefix;
     ecParams.tagSupplementary=opt::tagSupplementary;
     ecParams.percentageThreshold=opt::percentageThreshold;
+    ecParams.region=opt::region;
     ecParams.writeReadLog=opt::writeReadLog;
 
     HaplotagProcess processor(ecParams);

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -320,7 +320,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
     }
 
     // reference fasta parser
-    FastaParser fastaParser(params.fastaFile , chrVec, last_pos);
+    FastaParser fastaParser(params.fastaFile, chrVec, last_pos, params.numThreads);
 
     // write tag read detail information
     std::ofstream *tagResult=NULL;

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -90,7 +90,7 @@ void HaplotagProcess::unCompressParser(std::string &variantFile){
 }
 
 void HaplotagProcess::parserProcess(std::string &input){
-    if( input.find("#")!= std::string::npos && parseSnpFile ){
+    if( input.substr(0, 2) == "##" && parseSnpFile){
         if( input.find("contig=")!= std::string::npos ){
             int id_start  = input.find("ID=")+3;
             int id_end    = input.find(",length=");
@@ -103,7 +103,7 @@ void HaplotagProcess::parserProcess(std::string &input){
             chrVec.push_back(chr);
             chrLength[chr]=chrLen;
         }
-        if( input.find("ID=PS")!= std::string::npos ){
+        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
             if( input.find("Type=Integer")!= std::string::npos ){
                 integerPS = true;
             }
@@ -117,7 +117,10 @@ void HaplotagProcess::parserProcess(std::string &input){
             }
         }
     }
-    else if( input.find("#")== std::string::npos ){
+    else if ( input.substr(0, 1) == "#" ){
+
+    }
+    else{
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -118,7 +118,7 @@ void HaplotagProcess::parserProcess(std::string &input){
         }
     }
     else if ( input.substr(0, 1) == "#" ){
-
+        
     }
     else{
         std::istringstream iss(input);
@@ -279,6 +279,24 @@ void HaplotagProcess::parserProcess(std::string &input){
 
 void HaplotagProcess::tagRead(HaplotagParameters &params){
 
+    // update chromosome processing based on region
+    if (!params.region.empty()) {
+        auto colonPos = params.region.find(":");
+        std::string regionChr;
+        if (colonPos != std::string::npos) {
+            regionChr = params.region.substr(0, colonPos);
+        }
+        else {
+            regionChr = params.region;
+        }
+        auto chrVecIter = std::find(chrVec.begin(), chrVec.end(), regionChr);
+        if (chrVecIter != chrVec.end()) {
+            chrVec = std::vector<std::string>{regionChr};
+        } else {
+            std::cerr << "ERROR: Incorrect chromosome for input region\n" << std::endl;
+            exit(1);
+        }
+    }
     // input file management
     std::string openBamFile = params.bamFile;
     // open bam file
@@ -339,6 +357,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
             (*tagResult) << "##bamFile:"             << params.bamFile             << "\n";
             (*tagResult) << "##resultPrefix:"        << params.resultPrefix        << "\n";
             (*tagResult) << "##numThreads:"          << params.numThreads          << "\n";
+            (*tagResult) << "##region:"              << params.region              << "\n";
             (*tagResult) << "##qualityThreshold:"    << params.qualityThreshold    << "\n";
             (*tagResult) << "##percentageThreshold:" << params.percentageThreshold << "\n";
             (*tagResult) << "#tagSupplementary:"     << params.tagSupplementary    << "\n";
@@ -385,9 +404,9 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
         // fetch chromosome string
         std::string chr_reference = fastaParser.chrString.at(chr);
         
-        // tagging will be attempted for reads within the specified coordinate range.
-        std::string range = chr + ":1-" + std::to_string(chrLength[chr]);
-        hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
+        // tagging will be attempted for reads within the specified coordinate region.
+        std::string region = !params.region.empty() ? params.region : chr + ":1-" + std::to_string(chrLength[chr]);
+        hts_itr_t *iter = sam_itr_querys(idx, bamHdr, region.c_str());
         // iter all reads
         while ((result = sam_itr_multi_next(in, iter, aln)) >= 0) {
             totalAlignment++;
@@ -395,36 +414,22 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
 
             if ( aln->core.qual < params.qualityThreshold ){
                 // mapping quality is lower than threshold
-                // write this alignment to result bam file
-                result = sam_write1(out, bamHdr, aln);
-                continue;
             }
-
-            if( (flag & 0x4) != 0 ){
+            else if( (flag & 0x4) != 0 ){
                 // read unmapped
                 totalUnmapped++;
-                // write this alignment to result bam file
-                result = sam_write1(out, bamHdr, aln);
-                continue;
             }
-            if( (flag & 0x100) != 0 ){
+            else if( (flag & 0x100) != 0 ){
                 // secondary alignment. repeat.
                 // A secondary alignment occurs when a given read could align reasonably well to more than one place.
                 totalSecondary++;
-                // write this alignment to result bam file
-                result = sam_write1(out, bamHdr, aln);
-                continue;
             }
-            if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
+            else if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
                 // supplementary alignment
                 // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
                 totalSupplementary++;
-                // write this alignment to result bam file
-                result = sam_write1(out, bamHdr, aln);
-                continue;
             }
-
-            if(last == currentChrVariants.rend()){
+            else if(last == currentChrVariants.rend()){
                 // skip 
                 totalUnTagCuonnt++;
             }
@@ -807,6 +812,7 @@ totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),total
     std::cerr<< "write log file:    " << (params.writeReadLog ? "true" : "false") << "\n";
     std::cerr<< "log file:          " << (params.writeReadLog ? (params.resultPrefix+".out") : "") << "\n";
     std::cerr<< "-------------------------------------------\n";
+    std::cerr<< "tag region:                    " << (!params.region.empty() ? params.region : "all") << "\n";
     std::cerr<< "filter mapping quality below:  " << params.qualityThreshold    << "\n";
     std::cerr<< "percentage threshold:          " << params.percentageThreshold << "\n";
     std::cerr<< "tag supplementary:             " << (params.tagSupplementary ? "true" : "false") << "\n";

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -18,6 +18,7 @@ struct HaplotagParameters
     std::string bamFile;
     std::string fastaFile;
     std::string resultPrefix;
+    std::string region;
     
     bool tagSupplementary;
     bool writeReadLog;

--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -46,9 +46,7 @@ MethBamParser::~MethBamParser(){
     delete readStartEndMap;
 }
 
-void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec){
-    // init data structure and get core n
-    htsThreadPool threadPool = {NULL, 0};
+void MethBamParser::detectMeth(std::string chrName, int chr_len, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec){
 
     for( auto bamFile: params->bamFileVec ){
 
@@ -72,11 +70,7 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads,
 
         
         int result;
-        
-        // creat thread pool
-        if (!(threadPool.pool = hts_tpool_init(numThreads))) {
-            fprintf(stderr, "Error creating thread pool\n");
-        }
+
         hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
 
         while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) { 
@@ -99,7 +93,6 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads,
         bam_hdr_destroy(bamHdr);
         bam_destroy1(aln);
         sam_close(fp_in);
-        hts_tpool_destroy(threadPool.pool);
     }
 }
 

--- a/ModCallParsingBam.h
+++ b/ModCallParsingBam.h
@@ -87,7 +87,7 @@ class MethBamParser{
     public:
         MethBamParser(ModCallParameters &params, std::string &refString);
         ~MethBamParser();
-        void detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec);
+        void detectMeth(std::string chrName, int chr_len, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec);
         void exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,int> &passPosition, std::ostringstream &methResult);
         void judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &fReadVariantVec, std::vector<ReadVariant> &rReadVariantVec );
         void calculateDepth();

--- a/ModCallProcess.cpp
+++ b/ModCallProcess.cpp
@@ -18,14 +18,18 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         chrModCallResult[chrIter->name] = std::ostringstream();
     }
 
-    // set chrNumThreads and bamParserNumThreads based on parameters
-    int chrNumThreads,bamParserNumThreads;
-    setModcallNumThreads(params.numThreads, chrNumThreads, bamParserNumThreads);
-    // setNumThreads(chrInfo.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
+    // init data structure and get core n
+    htsThreadPool threadPool = {NULL, 0};
+
+    // creat thread pool
+    if (!(threadPool.pool = hts_tpool_init(params.numThreads))) {
+        fprintf(stderr, "Error creating thread pool\n");
+    }
+
     begin = time(NULL);
 
     //loop all chromosomes
-    #pragma omp parallel for schedule(dynamic) num_threads(chrNumThreads)
+    #pragma omp parallel for schedule(dynamic) num_threads(params.numThreads)
     for(auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); ++chrIter) {
         std::time_t chrbegin = time(NULL);
 
@@ -42,7 +46,7 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         
         MethBamParser *methbamparser = new MethBamParser(params, chrSeq);
         
-        methbamparser->detectMeth(chrName, chrLen, bamParserNumThreads, readVariantVec);
+        methbamparser->detectMeth(chrName, chrLen, threadPool, readVariantVec);
 
         //new new calculate depth
         methbamparser->calculateDepth();
@@ -80,6 +84,7 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
 
         std::cerr<< "(" << chrName << "," << difftime(time(NULL), chrbegin) << "s)";
     }
+    hts_tpool_destroy(threadPool.pool);
     std::cerr<< "\nmodcall total:  " << difftime(time(NULL), begin) << "s\n";
 
     begin= time(NULL);

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -909,7 +909,7 @@ BamParser::~BamParser(){
     delete currentMod;
 }
 
-void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string){
+void BamParser::direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string){
     
     // record SNP start iter
     std::map<int, RefAlt>::iterator tmpFirstVariantIter = firstVariantIter;
@@ -924,8 +924,6 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
         firstSVIter = tmpFirstSVIter;
         firstModIter = tmpFirstModIter;
 
-// init data structure and get core n
-        htsThreadPool threadPool = {NULL, 0};
         // open bam file
         samFile *fp_in = hts_open(bamFile.c_str(),"r"); 
         // load reference file
@@ -945,14 +943,8 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
         hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
 
         
-                int result;
-
-        // creat thread pool
-        if (!(threadPool.pool = hts_tpool_init(numThreads))) {
-            fprintf(stderr, "Error creating thread pool\n");
-        }
         hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
-        
+        int result;
         while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) { 
             int flag = aln->core.flag;
 
@@ -973,7 +965,6 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
         bam_hdr_destroy(bamHdr);
         bam_destroy1(aln);
         sam_close(fp_in);
-hts_tpool_destroy(threadPool.pool);
     }
     
 }

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -180,7 +180,7 @@ class BamParser{
         BamParser(std::string chrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile);
         ~BamParser();
         
-        void direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingParameters params, std::vector<ReadVariant> &readVariantVec , const std::string &ref_string);
+        void direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec , const std::string &ref_string);
 
 };
 

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -27,7 +27,7 @@ class FastaParser{
         std::vector<std::string> chrName;
         std::vector<int> last_pos;
     public:
-        FastaParser(std::string fastaFile  , std::vector<std::string> chrName , std::vector<int> last_pos);
+        FastaParser(std::string fastaFile, std::vector<std::string> chrName, std::vector<int> last_pos, int numThreads);
         ~FastaParser();
         
         // chrName, chr string

--- a/Phasing.cpp
+++ b/Phasing.cpp
@@ -18,8 +18,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "optional arguments:\n"
 "   --sv-file=NAME                         input SV vcf file.\n"
 "   --mod-file=NAME                        input modified vcf file.(produce by longphase modcall)\n"
-"   -t, --threads=Num                      number of thread. default:0\n"
-"                                          If set to 0, use all available threads.\n"
+"   -t, --threads=Num                      number of thread. default:1\n"
 "   -o, --out-prefix=NAME                  prefix of phasing result. default: result\n"
 "   --indels                               phase small indel. default: False\n"
 "   --dot                                  each contig/chromosome will generate dot file. \n\n"
@@ -68,7 +67,7 @@ static const struct option longopts[] = {
 
 namespace opt
 {
-    static int numThreads = 0;
+    static int numThreads = 1;
     static int distance = 300000;
     static std::string snpFile="";
     static std::string svFile="";
@@ -179,7 +178,7 @@ void PhasingOptions(int argc, char** argv)
         die = true;
     }  
     
-    if ( opt::numThreads < 0 ){
+    if ( opt::numThreads < 1 ){
         std::cerr << SUBPROGRAM " invalid threads. value: " 
                   << opt::numThreads 
                   << "\n please check -t, --threads=Num\n";

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -58,7 +58,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     for(auto chr :snpFile.getChrVec()){
         last_pos.push_back(snpFile.getLastSNP(chr));
     }
-    FastaParser fastaParser(params.fastaFile , snpFile.getChrVec(), last_pos);
+    FastaParser fastaParser(params.fastaFile, snpFile.getChrVec(), last_pos, params.numThreads);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
 
     // get all detected chromosome

--- a/Util.cpp
+++ b/Util.cpp
@@ -11,44 +11,6 @@ void mergeAllChrPhasingResult(const ChrPhasingResult& allChrPhasingResults, Phas
     }
 }
 
-void setPhasingNumThreads(const int& defaultChrThreads,const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads){
-    if(availableThreads == 0){
-        // The default thread value is 0, indicating that each chromosome concurrently utilizes 
-        // a single thread for computation. Due to the limited multithreading acceleration space 
-        // in htslib and an average utilization of no more than 5 threads per chromosome, the 
-        // default value is set to 5.
-        chrNumThreads = defaultChrThreads;
-        bamParserNumThreads = 5;
-    }
-    else if( defaultChrThreads > availableThreads){
-        // Due to the number of available threads being less than the number of chromosomes, 
-        // processing is performed on a subset of chromosomes equal to the availableThreads count, 
-        // with a limitation on the number of threads for reading the BAM file for each chromosome.
-        chrNumThreads = availableThreads;
-        bamParserNumThreads = 1;
-    }
-    else{
-        // If the number of available threads exceeds the count of chromosomes, the surplus 
-        // threads will be utilized to accelerate the speed of htslib in parsing BAM files.
-        chrNumThreads = defaultChrThreads;
-        bamParserNumThreads = std::max(1,availableThreads/defaultChrThreads);
-    }
-}
-
-void setModcallNumThreads(const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads){
-    // Using 4 threads in htslib tends to yield higher utilization.
-    // Allocate threads to the BAM parser, but do not exceed the maximum number of threads.
-    // This ensures that, even when more threads are available, the BAM parser does not use too many,
-    // thereby leaving resources available for other tasks.
-    const int maxBamParserThreads = 4;
-    bamParserNumThreads = std::min(maxBamParserThreads, availableThreads);
-
-    // Allocate at least one thread to the chromosome processing task.
-    // If there are enough available threads, the remaining threads will be allocated to this task.
-    // This allocation maintains a balance in the total number of threads used.
-    chrNumThreads = std::max(1, availableThreads / bamParserNumThreads);
-}
-
 std::string getTargetString(std::string line, std::string start_sign, std::string end_sign){
     int start = line.find(start_sign) + 1;
     int end   = line.find(end_sign);


### PR DESCRIPTION
- commit : [multithread fastaParser](https://github.com/twolinin/longphase/commit/2844e8a74dba6745b55f81d910f4039d5a64683b)
  data : GCA_000001405.15_GRCh38_no_alt_analysis_set.fa
  threads : 24
  before : 21s
  after : 2s
  use the feature : phase, haplotag
- commit : [thread pool to manage thread allocation](https://github.com/twolinin/longphase/commit/85c15d189d2a377cffc8460e914b268096dbeb4a)
  use the feature : phase, modcall

  This test compares the run times with the develop branch (commit https://github.com/twolinin/longphase/commit/d978d221f1cc1d1628cb214d47af35293133b326), performing phasing at 10x to 60x scale. The time format is `mm:ss`.
  Test Condition threads =24 | Run Time Before Optimization | Run Time After Optimization
  -- | -- | --
  HG002 ONT 10x | 01:22.77 | 00:53.60
  HG002 ONT 20x | 02:06.08 | 01:36.08
  HG002 ONT 30x | 02:58.30 | 01:26.28
  HG002 ONT 40x | 03:26.56 | 02:23.78
  HG002 ONT 50x | 04:05.03 | 03:15.71
  HG002 ONT 60x | 04:32.25 | 03:40.02
  
  Test Condition threads =100 | Run Time Before Optimization | Run Time After Optimization
  -- | -- | --
  HG002 ONT 10x | 01:26.66 | 00:53.60
  HG002 ONT 20x | 01:59.86 | 01:06.69
  HG002 ONT 30x | 02:42.54 | 01:48.90
  HG002 ONT 40x | 03:42.33 | 02:17.65
  HG002 ONT 50x | 04:01.23 | 02:45.05
  HG002 ONT 60x | 04:20.64 | 02:28.73

- commit : [Correct the conditions for judging the VCF header](https://github.com/twolinin/longphase/commit/2c505d391daab53d102ca5414ebbfd4233bffce3)
  use the feature : haplotag
- commit : [add region functionality](https://github.com/twolinin/longphase/commit/4446ecdb5170f848373d7c32256497bd73a9fb10)
  use the feature : haplotag
