### PR TITLE
Filtering alignments of the same read if there's an overlap ratio greater than the threshold

### DIFF
--- a/Haplotag.cpp
+++ b/Haplotag.cpp
@@ -22,6 +22,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "                                      if the alignment has no obvious corresponding haplotype, it will not be tagged. default:0.6\n"
 "      -t, --threads=Num               number of thread. default:1\n"
 "      -o, --out-prefix=NAME           prefix of phasing result. default:result\n"
+"      --cram                          the output file will be in the cram format. default:bam\n"
 "      --region=REGION                 tagging include only reads/variants overlapping those regions. default:\"\"(all regions)\n"
 "                                      input format:chrom (consider entire chromosome)\n"
 "                                                   chrom:start (consider region from this start to end of chromosome)\n"
@@ -31,7 +32,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 static const char* shortopts = "s:b:o:t:q:p:r:";
 
-enum { OPT_HELP = 1, TAG_SUP, SV_FILE, REGION, LOG, MOD_FILE};
+enum { OPT_HELP = 1, TAG_SUP, SV_FILE, REGION, LOG, MOD_FILE, CRAM};
 
 static const struct option longopts[] = { 
     { "help",                 no_argument,        NULL, OPT_HELP },
@@ -42,6 +43,7 @@ static const struct option longopts[] = {
     { "sv-file",              required_argument,  NULL, SV_FILE },
     { "mod-file",             required_argument,  NULL, MOD_FILE },
     { "out-prefix",           required_argument,  NULL, 'o' },
+    { "cram",                 no_argument,        NULL, CRAM },
     { "threads",              required_argument,  NULL, 't' },
     { "qualityThreshold",     required_argument,  NULL, 'q' },
     { "percentageThreshold",  required_argument,  NULL, 'p' },
@@ -62,8 +64,10 @@ namespace opt
     static std::string fastaFile="";
     static std::string resultPrefix="result";
     static std::string region="";
+    static std::string outputFormat="bam";
     static bool tagSupplementary = false;
     static bool writeReadLog = false;
+    
 }
 
 void HaplotagOptions(int argc, char** argv)
@@ -76,21 +80,23 @@ void HaplotagOptions(int argc, char** argv)
         std::istringstream arg(optarg != NULL ? optarg : "");
         switch (c)
         {
-        case 's': arg >> opt::snpFile; break;
-        case 't': arg >> opt::numThreads; break;
-        case 'b': arg >> opt::bamFile; break;
-        case 'r': arg >> opt::fastaFile; break; 
-        case 'o': arg >> opt::resultPrefix; break;
-        case 'q': arg >> opt::qualityThreshold; break;
-        case 'p': arg >> opt::percentageThreshold; break;
-        case SV_FILE: arg >> opt::svFile; break;
-        case MOD_FILE: arg >> opt::modFile; break;
-        case TAG_SUP: opt::tagSupplementary = true; break;
-        case REGION: arg >> opt::region; break;
-        case LOG: opt::writeReadLog = true; break;
-        case OPT_HELP:
-            std::cout << CORRECT_USAGE_MESSAGE;
-            exit(EXIT_SUCCESS);
+            case 's': arg >> opt::snpFile; break;
+            case 't': arg >> opt::numThreads; break;
+            case 'b': arg >> opt::bamFile; break;
+            case 'r': arg >> opt::fastaFile; break; 
+            case 'o': arg >> opt::resultPrefix; break;
+            case 'q': arg >> opt::qualityThreshold; break;
+            case 'p': arg >> opt::percentageThreshold; break;
+            case SV_FILE:  arg >> opt::svFile; break;
+            case MOD_FILE: arg >> opt::modFile; break;     
+            case REGION:   arg >> opt::region; break;        
+            case TAG_SUP:  opt::tagSupplementary = true; break;
+            case CRAM:     opt::outputFormat = "cram"; break;
+            case LOG:      opt::writeReadLog = true; break;
+            case OPT_HELP:
+                std::cout << CORRECT_USAGE_MESSAGE;
+                exit(EXIT_SUCCESS);
+            default: die = true; break;
         }
     }
 
@@ -202,6 +208,7 @@ int HaplotagMain(int argc, char** argv)
     ecParams.percentageThreshold=opt::percentageThreshold;
     ecParams.region=opt::region;
     ecParams.writeReadLog=opt::writeReadLog;
+    ecParams.outputFormat=opt::outputFormat;
 
     HaplotagProcess processor(ecParams);
 

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -317,9 +317,11 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
     }
 
     // output file mangement
-    std::string writeBamFile = params.resultPrefix + ".bam";
+    std::string writeBamFile = params.resultPrefix + "." + params.outputFormat;
     // open output bam file
-    samFile *out = hts_open(writeBamFile.c_str(), "wb");
+    samFile *out = hts_open(writeBamFile.c_str(), (params.outputFormat == "bam" ? "wb" : "wc" ));
+    // load reference file
+    hts_set_fai_filename(out, params.fastaFile.c_str() );
     // output writer
     int result = sam_hdr_write(out, bamHdr);
     // check index file
@@ -817,10 +819,10 @@ totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),total
 {
     std::cerr<< "phased SNP file:   " << params.snpFile             << "\n";
     std::cerr<< "phased SV file:    " << params.svFile              << "\n";
-    std::cerr<< "phased MOD file:   " << params.modFile              << "\n";
+    std::cerr<< "phased MOD file:   " << params.modFile             << "\n";
     std::cerr<< "input bam file:    " << params.bamFile             << "\n";
     std::cerr<< "input ref file:    " << params.fastaFile           << "\n";
-    std::cerr<< "output bam file:   " << params.resultPrefix+".bam" << "\n";
+    std::cerr<< "output bam file:   " << params.resultPrefix + "." + params.outputFormat << "\n";
     std::cerr<< "number of threads: " << params.numThreads          << "\n";
     std::cerr<< "write log file:    " << (params.writeReadLog ? "true" : "false") << "\n";
     std::cerr<< "log file:          " << (params.writeReadLog ? (params.resultPrefix+".out") : "") << "\n";

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -19,6 +19,7 @@ struct HaplotagParameters
     std::string fastaFile;
     std::string resultPrefix;
     std::string region;
+    std::string outputFormat;
     
     bool tagSupplementary;
     bool writeReadLog;

--- a/Phasing.cpp
+++ b/Phasing.cpp
@@ -33,6 +33,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "   -d, --distance=Num                     phasing two variant if distance less than threshold. default:300000\n"
 "   -1, --edgeThreshold=[0~1]              give up SNP-SNP phasing pair if the number of reads of the \n"
 "                                          two combinations are similar. default:0.7\n"
+"   -L, --overlapThreshold=[0~1]           filtering different alignments of the same read if there is overlap. default:0.2 \n"
 
 "haplotag read correction arguments:\n"
 "   -m, --readConfidence=[0.5~1]           The confidence of a read being assigned to any haplotype. default:0.65\n"
@@ -40,7 +41,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 "\n";
 
-static const char* shortopts = "s:b:o:t:r:d:1:a:q:p:e:n:m:";
+static const char* shortopts = "s:b:o:t:r:d:1:a:q:p:e:n:m:L:";
 
 enum { OPT_HELP = 1 , DOT_FILE, SV_FILE, MOD_FILE, IS_ONT, IS_PB, PHASE_INDEL, VERSION};
 
@@ -62,10 +63,11 @@ static const struct option longopts[] = {
     { "edgeThreshold",        required_argument,  NULL, '1' },
     { "connectAdjacent",      required_argument,  NULL, 'a' },
     { "mappingQuality",       required_argument,  NULL, 'q' },
-    { "baseQuality",       required_argument,  NULL, 'p' },
-    { "edgeWeight",       required_argument,  NULL, 'e' },
+    { "baseQuality",          required_argument,  NULL, 'p' },
+    { "edgeWeight",           required_argument,  NULL, 'e' },
     { "snpConfidence",        required_argument,  NULL, 'n' },
     { "readConfidence",       required_argument,  NULL, 'm' },
+    { "overlapThreshold",     required_argument,  NULL, 'L' },
     { NULL, 0, NULL, 0 }
 };
 
@@ -94,6 +96,7 @@ namespace opt
     static double readConfidence = 0.65;
     
     static double edgeThreshold = 0.7;
+    static double overlapThreshold = 0.2;
 
     static std::string command;
 }
@@ -116,10 +119,11 @@ void PhasingOptions(int argc, char** argv)
         case '1': arg >> opt::edgeThreshold; break; 
         case 'a': arg >> opt::connectAdjacent; break;
         case 'q': arg >> opt::mappingQuality; break;
-	case 'p': arg >> opt::baseQuality; break;
-	case 'e': arg >> opt::edgeWeight; break;
+        case 'p': arg >> opt::baseQuality; break;
+        case 'e': arg >> opt::edgeWeight; break;
         case 'n': arg >> opt::snpConfidence; break;
         case 'm': arg >> opt::readConfidence; break;
+        case 'L': arg >> opt::overlapThreshold; break;
         case 'b': {
             std::string bamFile;
             arg >> bamFile;
@@ -236,6 +240,13 @@ void PhasingOptions(int argc, char** argv)
         die = true;
     }
     
+    if ( opt::overlapThreshold < 0 || opt::overlapThreshold > 1 ){
+        std::cerr << SUBPROGRAM " invalid overlapThreshold. value: " 
+                  << opt::overlapThreshold 
+                  << "\n please check -L, --overlapThreshold=[0~1]\n";
+        die = true;
+    }
+    
     if ( opt::readConfidence < 0.5 || opt::readConfidence > 1 ){
         std::cerr << SUBPROGRAM " invalid readConfidence. value: " 
                   << opt::readConfidence 
@@ -285,6 +296,7 @@ int PhasingMain(int argc, char** argv, std::string in_version)
     ecParams.edgeWeight=opt::edgeWeight;
 
     ecParams.edgeThreshold=opt::edgeThreshold;
+    ecParams.overlapThreshold=opt::overlapThreshold;
     
     ecParams.snpConfidence=opt::snpConfidence;
     ecParams.readConfidence=opt::readConfidence;

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -418,13 +418,14 @@ void VairiantGraph::destroy(){
 void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
     readVariant = &in_readVariant;
     std::map<std::string,ReadVariant> mergeReadMap;
-    /*
+
     // each read will record fist and list variant posistion
     std::map<std::string, std::pair<int,int>> alignRange;
-    std::map<std::string, bool> alignmentOverlap;
-    
-    // Check if different alignments of a read have overlap
-    for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
+    // record an iterator for all alignments of a read.
+    std::map<std::string, std::vector<std::vector<ReadVariant>::iterator>> readIterVec;
+
+    // Check for overlaps among different alignments of a read and filter out the shorter overlapping alignments.
+    for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ;  ){
         std::string readName = (*readIter).read_name;
         int firstVariantPos = (*readIter).variantVec[0].position;
         int lastVariantPos  = (*readIter).variantVec[(*readIter).variantVec.size()-1].position;
@@ -433,21 +434,59 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
         // this read name appears for the first time
         if( rangeIter == alignRange.end() ){
             alignRange[readName]=std::make_pair(firstVariantPos,lastVariantPos);
-            alignmentOverlap[readName]=false;
         }
         // the read appears more than once, check if the alignments overlap
         else{
             // overlap
             if( alignRange[readName].first <= firstVariantPos && firstVariantPos <= alignRange[readName].second ){
-                alignmentOverlap[readName]=true;
+                double alignStart   = std::min(alignRange[readName].first, firstVariantPos);
+                double alignEnd     = std::max(alignRange[readName].second, lastVariantPos);
+                double alignSpan    = alignEnd - alignStart + 1;
+                double overlapStart = std::max(alignRange[readName].first, firstVariantPos);
+                double overlapEnd   = std::min(alignRange[readName].second, lastVariantPos);
+                double overlapLen   = overlapEnd - overlapStart + 1;
+                double overlapRatio = overlapLen / alignSpan;
+                
+                //filtering highly overlapping alignments.
+                if( overlapRatio >= params->overlapThreshold ){
+                    int alignLen1 = alignRange[readName].second - alignRange[readName].first + 1;
+                    int alignLen2 = lastVariantPos - firstVariantPos + 1;
+                    
+                    // filter shorter alignment
+                    // current alignment is shorter
+                    if( alignLen2 <= alignLen1 ){
+                        in_readVariant.erase(readIter);
+                    }
+                    // previous alignment is shorter
+                    else{
+                        // previous has more than one alignment
+                        if( readIterVec[readName].size() > 1 ){
+                            // iterate and erase all previous alignments
+                            for(int iter = readIterVec[readName].size()-1 ; iter >= 0 ; iter-- ){
+                                in_readVariant.erase(readIterVec[readName][iter]);
+                            }
+                        }
+                        // previous has only one alignment
+                        else{
+                            in_readVariant.erase(readIterVec[readName][0]);
+                        }
+                        // update range
+                        alignRange[readName].first  = firstVariantPos;
+                        alignRange[readName].second = lastVariantPos;
+                        readIterVec[readName].clear();
+                        readIterVec[readName][0] = readIter;
+                    }
+                    continue;
+                }
             }
-            // no verlap, update range
-            else{
-                alignRange[readName].second = lastVariantPos;
-            }
+            // update range
+            alignRange[readName].second = lastVariantPos;
         }
+        readIterVec[readName].push_back(readIter);
+        // iter next alignment
+        readIter++;
     }
-    */
+
     int readCount=0;
     // merge alignment
     for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
@@ -483,13 +522,7 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
                 (*variantType)[variant.position] = 0;
             }
             mergeReadMap[(*readIter).read_name].variantVec.push_back(variant);
-            /*
-            if( !alignmentOverlap[(*readIter).read_name] ){
-                mergeReadMap[(*readIter).read_name].variantVec.push_back(variant);
-            }
-            else{
-                mergeReadMap[(*readIter).read_name+std::to_string(readCount)].variantVec.push_back(variant);
-            }*/
+
             //tmpRead.variantVec.push_back(variant);
             
             // Each position will record the included reads and their corresponding base qualities.
@@ -537,86 +570,6 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
         }
     }
 
-    
-    
-    /*
-    readVariant = &in_readVariant;
-    // iter all read
-    for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
-        // Creating a pseudo read which allows filtering out variants that should not be phased
-        ReadVariant tmpRead;
-        // Visiting all the variants on the read
-        for( auto variant : (*readIter).variantVec ){
-            
-            // modification
-            if( variant.quality == -2 || variant.quality == -3 ){
-                (*variantType)[variant.position] = 2;
-                variant.quality = 60;
-            }
-            // structure variation
-            else if( variant.quality == -1 ){
-                (*variantType)[variant.position] = 1;
-                if( variant.allele == 1 ){
-                    // SVcaller calling
-                    variant.quality = 60; 
-                }
-                else{
-                    // In SVcaller, unmarked reads are assumed to be REF
-                    variant.quality = 30;
-                }
-            }
-            // indel
-            else if( variant.quality == -4 ){
-                (*variantType)[variant.position] = 3;
-                variant.quality = 60;
-            }
-            // The remaining variants will be labeled as SNPs
-            else{
-                (*variantType)[variant.position] = 0;
-            }
-            
-            tmpRead.variantVec.push_back(variant);
-            
-            // Each position will record the included reads and their corresponding base qualities.
-            auto variantIter = totalVariantInfo->find(variant.position);
-            
-            if( variantIter == totalVariantInfo->end() ){
-                (*totalVariantInfo)[variant.position] = new ReadBaseMap();
-            }
-            
-            (*(*totalVariantInfo)[variant.position])[(*readIter).read_name] = variant.quality;
-        }
-        
-        // iter all pair of snp and construct initial graph
-        std::vector<Variant>::iterator variant1Iter = tmpRead.variantVec.begin();
-        std::vector<Variant>::iterator variant2Iter = std::next(variant1Iter,1);
-        while(variant1Iter != tmpRead.variantVec.end() && variant2Iter != tmpRead.variantVec.end() ){
-            // create new edge if not exist
-            std::map<int,VariantEdge*>::iterator posIter = edgeList->find((*variant1Iter).position);
-            if( posIter == edgeList->end() )
-                (*edgeList)[(*variant1Iter).position] = new VariantEdge((*variant1Iter).position);
-
-            // add edge process
-            for(int nextNode = 0 ; nextNode < params->connectAdjacent; nextNode++){
-                // this allele support ref
-                if( (*variant1Iter).allele == 0 )
-                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,params->baseQuality,params->edgeWeight);
-                // this allele support alt
-                if( (*variant1Iter).allele == 1 )
-                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,params->baseQuality,params->edgeWeight);
-                
-                // next snp
-                variant2Iter++;
-                if( variant2Iter == tmpRead.variantVec.end() ){
-                    break;
-                }
-            }
-
-            variant1Iter++;
-            variant2Iter = std::next(variant1Iter,1);
-        }
-    }
-    */
 } 
 
 void VairiantGraph::readCorrection(){

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -26,6 +26,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     std::cerr<< "Distance Threshold : " << params.distance        << "\n";
     std::cerr<< "Connect Adjacent   : " << params.connectAdjacent << "\n";
     std::cerr<< "Edge Threshold     : " << params.edgeThreshold   << "\n";
+    std::cerr<< "Overlap Threshold  : " << params.overlapThreshold   << "\n";
     std::cerr<< "Mapping Quality    : " << params.mappingQuality  << "\n";
     std::cerr<< "Variant Confidence : " << params.snpConfidence   << "\n";
     std::cerr<< "ReadTag Confidence : " << params.readConfidence  << "\n";

--- a/PhasingProcess.h
+++ b/PhasingProcess.h
@@ -29,6 +29,7 @@ struct PhasingParameters
     double readConfidence;
     
     double edgeThreshold;
+    double overlapThreshold;
     
     std::string version;
     std::string command;

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 
 
 #define PROGRAM_BIN "main"
-#define VERSION "1.7.1dev"
+#define VERSION "1.7.2dev"
 
 static std::string version = VERSION;
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 
 
 #define PROGRAM_BIN "main"
-#define VERSION "1.7"
+#define VERSION "1.7.1dev"
 
 static std::string version = VERSION;
 


### PR DESCRIPTION
1. Haplotag offers the option `--cram` to output CRAM format. By default, it outputs BAM format.
2. Filtering different alignments of the same read if there's an overlap ratio greater than the threshold.
3. Correcting the bug where a few alignments are mistakenly deleted as another alignment during the removal process when using the iterator store for the alignments to be removed.