### PR TITLE
Header add pg tag

### DIFF
--- a/Haplotag.cpp
+++ b/Haplotag.cpp
@@ -64,6 +64,7 @@ namespace opt
     static std::string region="";
     static bool tagSupplementary = false;
     static bool writeReadLog = false;
+    static std::string command="longphase ";
 }
 
 void HaplotagOptions(int argc, char** argv)
@@ -92,6 +93,11 @@ void HaplotagOptions(int argc, char** argv)
             std::cout << CORRECT_USAGE_MESSAGE;
             exit(EXIT_SUCCESS);
         }
+    }
+
+    for(int i = 0; i < argc; ++i){
+        opt::command.append(argv[i]);
+        opt::command.append(" ");
     }
 
     if (argc - optind < 0 )
@@ -184,7 +190,7 @@ void HaplotagOptions(int argc, char** argv)
 
 }
 
-int HaplotagMain(int argc, char** argv)
+int HaplotagMain(int argc, char** argv, std::string in_version)
 {
     HaplotagParameters ecParams;
     // set parameters
@@ -202,6 +208,8 @@ int HaplotagMain(int argc, char** argv)
     ecParams.percentageThreshold=opt::percentageThreshold;
     ecParams.region=opt::region;
     ecParams.writeReadLog=opt::writeReadLog;
+    ecParams.version=in_version;
+    ecParams.command=opt::command;
 
     HaplotagProcess processor(ecParams);
 

--- a/Haplotag.h
+++ b/Haplotag.h
@@ -1,8 +1,9 @@
 #ifndef HAPLOTAG_H
 #define HAPLOTAG_H
+#include "Util.h"
 
 // functions
-int HaplotagMain(int argc, char** argv);
+int HaplotagMain(int argc, char** argv, std::string in_version);
 
 // options
 void HaplotagOptions(int argc, char** argv);

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -418,24 +418,24 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
 
             if ( aln->core.qual < params.qualityThreshold ){
                 // mapping quality is lower than threshold
-		        totalUnTagCount++;
+                totalUnTagCount++;
             }
             else if( (flag & 0x4) != 0 ){
                 // read unmapped
                 totalUnmapped++;
-		        totalUnTagCount++;
+                totalUnTagCount++;
             }
             else if( (flag & 0x100) != 0 ){
                 // secondary alignment. repeat.
                 // A secondary alignment occurs when a given read could align reasonably well to more than one place.
                 totalSecondary++;
-		        totalUnTagCount++;
+                totalUnTagCount++;
             }
             else if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
                 // supplementary alignment
                 // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
                 totalSupplementary++;
-		        totalUnTagCount++;
+                totalUnTagCount++;
             }
             else if(last == currentChrVariants.rend()){
                 // skip 
@@ -447,7 +447,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
                     totalSupplementary++;
                 }
 
-		        int pqValue = 0;
+                int pqValue = 0;
                 int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue, chr_reference);
 
                 initFlag(aln, "HP");

--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -305,6 +305,8 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
     hts_set_fai_filename(in, params.fastaFile.c_str() );
     // input reader
     bam_hdr_t *bamHdr = sam_hdr_read(in);
+    // header add pg tag
+    sam_hdr_add_pg(bamHdr, "longphase", "VN", params.version.c_str(), "CL", params.command.c_str(), NULL);
     // bam file index
     hts_idx_t *idx = NULL;
     // check input bam file
@@ -414,24 +416,24 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
 
             if ( aln->core.qual < params.qualityThreshold ){
                 // mapping quality is lower than threshold
-		totalUnTagCount++;
+		        totalUnTagCount++;
             }
             else if( (flag & 0x4) != 0 ){
                 // read unmapped
                 totalUnmapped++;
-		totalUnTagCount++;
+		        totalUnTagCount++;
             }
             else if( (flag & 0x100) != 0 ){
                 // secondary alignment. repeat.
                 // A secondary alignment occurs when a given read could align reasonably well to more than one place.
                 totalSecondary++;
-		totalUnTagCount++;
+		        totalUnTagCount++;
             }
             else if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
                 // supplementary alignment
                 // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
                 totalSupplementary++;
-		totalUnTagCount++;
+		        totalUnTagCount++;
             }
             else if(last == currentChrVariants.rend()){
                 // skip 
@@ -439,11 +441,11 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
             }
             else if(int(aln->core.pos) <= (*last).first){
                 
-		if( (flag & 0x800) != 0 ){
-		    totalSupplementary++;
-		}
+                if( (flag & 0x800) != 0 ){
+                    totalSupplementary++;
+                }
 
-		int pqValue = 0;
+		        int pqValue = 0;
                 int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue, chr_reference);
 
                 initFlag(aln, "HP");
@@ -462,9 +464,9 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
                     totalUnTagCount++;
                 }
             }
-	    else{
+            else{
                 totalUnTagCount++;
-	    }
+            }
 
             // write this alignment to result bam file
             result = sam_write1(out, bamHdr, aln);

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -19,6 +19,8 @@ struct HaplotagParameters
     std::string fastaFile;
     std::string resultPrefix;
     std::string region;
+    std::string command;
+    std::string version;
     
     bool tagSupplementary;
     bool writeReadLog;

--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     }
     else if(command=="haplotag")
     {
-        HaplotagMain(argc - 1, argv + 1);
+        HaplotagMain(argc - 1, argv + 1, version);
     }
     else if(command=="modcall")
     {


### PR DESCRIPTION
- Using the command `samtools view -H read_file`, can view the haplotag records within the read_file header.

  ```
  @PG     ID:longphase.140        PN:longphase    PP:samtools.283 VN:1.7.2dev     CL:longphase haplotag -b hg002.sup.10x.bam -r GCA_000001405.15_GRCh38_no_alt_analysis_set.fa -s result.vcf -t 100 --region chr20
  ```