### PR TITLE
LongPhase 1.7.3 Release Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ LongPhase is an ultra-fast program for simultaneously co-phasing SNPs, small ind
 - [Contact](#contact)
 ---
 ## Installation
-You are recommended to download a [linux 64bit binary release](https://github.com/twolinin/longphase/releases/download/v1.7.1/longphase_linux-x64.tar.xz) without compilation. 
+You are recommended to download a [linux 64bit binary release](https://github.com/twolinin/longphase/releases/download/v1.7.2/longphase_linux-x64.tar.xz) without compilation. 
 
 ```
-wget https://github.com/twolinin/longphase/releases/download/v1.7.1/longphase_linux-x64.tar.xz
+wget https://github.com/twolinin/longphase/releases/download/v1.7.2/longphase_linux-x64.tar.xz
 tar -xJf longphase_linux-x64.tar.xz
 ```
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 
 
 #define PROGRAM_BIN "main"
-#define VERSION "1.7.2dev"
+#define VERSION "1.7.2"
 
 
 static std::string version = VERSION;


### PR DESCRIPTION
### Summary
Fix the issue where the `phase` command calls `fai_load()` each time it fetches a reference sequence, changing it to call only once.

### Changes
1. #76