### PR TITLE
Pochung

### DIFF
--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -268,6 +268,7 @@ void MethBamParser::exportResult(std::string chrName, std::string chrSquence, in
         auto prepassPosIter =  passPosition.find((*posinfoIter).first - 1);
         auto nextpassPosIter =  passPosition.find((*posinfoIter).first + 1);
         
+        // Determine continuous methylation position (CpG) that can be output
         if(!passPosition[passPosIter->first].empty() && !passPosition[prepassPosIter->first].empty()){
             for(std::vector<int>::iterator posIter = passPosition[passPosIter->first].begin(); posIter != passPosition[passPosIter->first].end(); posIter++){
                 for(std::vector<int>::iterator posIter2 = passPosition[prepassPosIter->first].begin(); posIter2 != passPosition[prepassPosIter->first].end(); posIter2++){

--- a/ModCallParsingBam.h
+++ b/ModCallParsingBam.h
@@ -88,7 +88,7 @@ class MethBamParser{
         MethBamParser(ModCallParameters &params, std::string &refString);
         ~MethBamParser();
         void detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec);
-        void exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,int> &passPosition, std::ostringstream &methResult);
+        void exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,std::vector<int>> &passPosition, std::ostringstream &methResult);
         void judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &fReadVariantVec, std::vector<ReadVariant> &rReadVariantVec );
         void calculateDepth();
         
@@ -119,7 +119,7 @@ class MethylationGraph{
         ~MethylationGraph();
         
         void addEdge(std::vector<ReadVariant> &readVariant);
-        void connectResults(std::string chrName, std::map<int,int> &passPosition);
+        void connectResults(std::string chrName, std::map<int,std::vector<int>> &passPosition);
         
         void destroy();
 };

--- a/ModCallProcess.cpp
+++ b/ModCallProcess.cpp
@@ -23,7 +23,6 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
     setModcallNumThreads(params.numThreads, chrNumThreads, bamParserNumThreads);
     // setNumThreads(chrInfo.size(), params.numThreads, chrNumThreads, bamParserNumThreads);
     begin = time(NULL);
-
     //loop all chromosomes
     #pragma omp parallel for schedule(dynamic) num_threads(chrNumThreads)
     for(auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); ++chrIter) {
@@ -34,7 +33,7 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         std::vector<ReadVariant> rReadVariantVec;
         std::vector<ReadVariant> readVariantVec;
         // record hetero metyhl position
-        std::map<int,int> *passPosition = new std::map<int,int>;
+        std::map<int,std::vector<int>> *passPosition = new std::map<int,std::vector<int>>;
 
         std::string chrName = chrIter->name;
         std::string chrSeq = chrIter->sequence;
@@ -46,10 +45,8 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
 
         //new new calculate depth
         methbamparser->calculateDepth();
-        
         //judge methylation genotype
         methbamparser->judgeMethGenotype(chrName, readVariantVec, fReadVariantVec, rReadVariantVec);
-
         MethylationGraph *fGraph = new MethylationGraph(params);
         MethylationGraph *rGraph = new MethylationGraph(params);
         fGraph->addEdge(fReadVariantVec);
@@ -65,7 +62,6 @@ ModCallProcess::ModCallProcess(ModCallParameters params){
         
         //push result to ModCallResult
         methbamparser->exportResult(chrName, chrSeq, chrLen, (*passPosition), chrModCallResult[chrName]);
-        
         passPosition->clear();
         
         delete methbamparser;

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -55,7 +55,7 @@ void SubEdge::addSubEdge(int currentQuality, Variant connectNode, std::string re
         else{
             (*altQuality)[connectNode.position] += currentQuality + connectNode.quality;
         }*/
-	if ( currentQuality >= baseQuality && connectNode.quality >= baseQuality )
+	    if ( currentQuality >= baseQuality && connectNode.quality >= baseQuality )
             (*altReadCount)[connectNode.position]++;
         else {
             (*altReadCount)[connectNode.position] = (*altReadCount)[connectNode.position] + edgeWeight ;

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -184,6 +184,7 @@ std::pair<PosAllele,PosAllele> VariantEdge::findBestEdgePair(int targetPos, bool
         // not sure which is better
     }
 
+    //VarintType < 0=SNP 1=SV 2=MOD 3=INDEL 4=tandem repeat INDEL >
     if((variantType[currPos] == 0 && variantType[targetPos] == 2)||(variantType[currPos] == 2 && variantType[targetPos] == 0)){
         edgeThreshold = 0.3;
         if((rr+ra+ar+aa) < 1){
@@ -606,6 +607,7 @@ void VairiantGraph::readCorrection(){
             //block = nodePS->second;
             if( nodePS != bkResult->end() ){
                 if((*bkResult)[refAllele] != 0 ){
+                    //VarintType < 0=SNP 1=SV 2=MOD 3=INDEL 4=tandem repeat INDEL >
                     if((*variantType)[variant.position] == 0){
                         if((*subNodeHP)[refAllele]==0)refCount++;
                         else altCount++;

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -265,7 +265,6 @@ void VairiantGraph::edgeConnectResult(){
         int h1 = (*hpCountMap)[currPos][1].size();
         int h2 = (*hpCountMap)[currPos][2].size();
 
-        std::cout << currPos << "\t" << h1 << "\t" << h2 << "\n"; 
         // new block, set this position as block start 
         if( h1 == 0 && h2 == 0 ){
             // No new blocks should be created if the next SNP has already been picked up

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -197,7 +197,7 @@ std::pair<PosAllele,PosAllele> VariantEdge::findBestEdgePair(int targetPos, bool
     }
     
     if(debug){
-        std::cout << currPos+1 << "\t->\t" << targetPos+1 << "\t|rr aa | ra ar\t" << "\t" << rr << "\t" << aa << "\t" << ra << "\t" << ar  << "\n";
+        std::cout << currPos << "\t->\t" << targetPos << "\t|rr aa | ra ar\t" << "\t" << rr << "\t" << aa << "\t" << ra << "\t" << ar  << "\n";
     }
     
     // create edge pairs
@@ -264,7 +264,7 @@ void VairiantGraph::edgeConnectResult(){
         int h1 = (*hpCountMap)[currPos][1].size();
         int h2 = (*hpCountMap)[currPos][2].size();
 
-        std::cout << currPos+1 << "\t" << h1 << "\t" << h2 << "\n"; 
+        std::cout << currPos << "\t" << h1 << "\t" << h2 << "\n"; 
         // new block, set this position as block start 
         if( h1 == 0 && h2 == 0 ){
             // No new blocks should be created if the next SNP has already been picked up
@@ -293,7 +293,7 @@ void VairiantGraph::edgeConnectResult(){
         // check connect between surrent SNP and next n SNPs
         for(int i = 0 ; i < params->connectAdjacent ; i++ ){
             // consider reads from the currnt SNP and the next (i+1)'s SNP
-            std::pair<PosAllele,PosAllele> tmp = edgeIter->second->findBestEdgePair(nextNodeIter->first, params->isONT, params->edgeThreshold, true, *variantType);
+            std::pair<PosAllele,PosAllele> tmp = edgeIter->second->findBestEdgePair(nextNodeIter->first, params->isONT, params->edgeThreshold, false, *variantType);
             // -1 : no connect  
             //  1 : the haplotype of next (i+1)'s SNP are same as previous
             //  2 : the haplotype of next (i+1)'s SNP are different as previous

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -186,24 +186,10 @@ std::pair<PosAllele,PosAllele> VariantEdge::findBestEdgePair(int targetPos, bool
 
     if((variantType[currPos] == 0 && variantType[targetPos] == 2)||(variantType[currPos] == 2 && variantType[targetPos] == 0)){
         edgeThreshold = 0.3;
-        /*if(targetPos - currPos > 30000){
-            edgeThreshold = 0.1;
-            if((rr+ra+ar+aa) < 1){
-                edgeThreshold = -1;
-            }
-        }*/
         if((rr+ra+ar+aa) < 1){
             edgeThreshold = -1;
         }
     }
-
-
-    /*if(variantType[currPos] == 2 && variantType[targetPos] == 2){
-        edgeThreshold = 0.6;
-        if((rr+ra+ar+aa) < 1){
-            edgeThreshold = -1;
-        }
-    }*/
 
     if( edgeSimilarRatio > edgeThreshold ){
         refAllele = -1;
@@ -254,10 +240,6 @@ void VairiantGraph::edgeConnectResult(){
     int currPos = -1;
     int nextPos = -1;
     int lastConnectPos = -1;
-    
-    // std::ostringstream fileName;
-    // fileName << "/bip8_disk/pochung112/modphase-output/"<< chr << ".log";
-    // std::ofstream outFile(fileName.str(), std::ios::app);
 
     // Visit all position and assign SNPs to haplotype.
     // Avoid recording duplicate information,

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -8,12 +8,6 @@
 
 typedef std::pair<int, int> PosAllele;
 typedef std::map<std::string, int> ReadBaseMap;
-/*struct ReadBaseInfo{
-    std::string readName;
-    int quality;
-    // 0=SNP 1=SV 2=MOD 3=INDEL
-    int type;
-};*/
 
 class SubEdge{
     
@@ -90,7 +84,7 @@ class VairiantGraph{
         // position, edge
         std::map<int,VariantEdge*> *edgeList;
         // Each position will record the included reads and their corresponding base qualities.
-        // position, < read name, ReadBaseInfo>
+        // position, < read name, quality>
         std::map<int,ReadBaseMap*> *totalVariantInfo;
         // position, type < 0=SNP 1=SV 2=MOD 3=INDEL >
         std::map<int,int> *variantType;

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -8,6 +8,12 @@
 
 typedef std::pair<int, int> PosAllele;
 typedef std::map<std::string, int> ReadBaseMap;
+/*struct ReadBaseInfo{
+    std::string readName;
+    int quality;
+    // 0=SNP 1=SV 2=MOD 3=INDEL
+    int type;
+};*/
 
 class SubEdge{
     
@@ -53,7 +59,7 @@ struct VariantEdge{
 
     VariantEdge(int currPos);
     // node pair 
-    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug);
+    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, std::map<int,int> &variantType/*, std::ofstream& outFile*/);
     // number of read of two node. AA and AB combination
     std::pair<int,int> findNumberOfRead(int targetPos);
 };
@@ -84,7 +90,7 @@ class VairiantGraph{
         // position, edge
         std::map<int,VariantEdge*> *edgeList;
         // Each position will record the included reads and their corresponding base qualities.
-        // position, < read name, quality>
+        // position, < read name, ReadBaseInfo>
         std::map<int,ReadBaseMap*> *totalVariantInfo;
         // position, type < 0=SNP 1=SV 2=MOD 3=INDEL >
         std::map<int,int> *variantType;

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -59,7 +59,7 @@ struct VariantEdge{
 
     VariantEdge(int currPos);
     // node pair 
-    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, std::map<int,int> &variantType/*, std::ofstream& outFile*/);
+    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, std::map<int,int> &variantType);
     // number of read of two node. AA and AB combination
     std::pair<int,int> findNumberOfRead(int targetPos);
 };


### PR DESCRIPTION
In the program ModCallParsingBam.cpp, within the function exportResult, modify the selection mechanism of ModCall so that methylation site are selected only if both consecutive positions on CpG island meet the criteria with another CpG island.

In the program PhasingGraph.cpp, within the function findBestEdgePair, if the situation involves a methylation site connecting to an SNP or an SNP connecting to a methylation site, change the edgeThreshold from 0.7 to 0.3.

In the program PhasingGraph.cpp, within the function ReadCorrection, adjust the weights of SNP, SV, MOD, and INDEL in ReadCorrection. SNP and SV has weight 1, INDEL has weight 0.1 and MOD has weight 0.
Explain the types of variants and weighted using comments.

Before modification, switch error values for 10x-60x are 1123, 1286, 1262, 1279, 1287, 1292, respectively.
After modification, switch error values for 10x-60x are 1124, 1264, 1233, 1255, 1262, 1272, respectively.
Before modification, n50 values for 10x-60x are 808264, 1814440, 2658491, 3384448, 3969440, 5329227, respectively.
After modification, n50 values for 10x-60x are 809291, 1814734, 2677820, 3371590, 3920477, 5348064, respectively.

