### PR TITLE
Improving the SNP phasing and INDEL cophasing

### DIFF
--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -333,19 +333,21 @@ std::map<int, RefAlt> SnpParser::getVariants_markindel(std::string chrName, cons
             int variant_pos = innerIter->first;      // Accessing the variant_pos of the inner map
             RefAlt variant_info = innerIter->second; // Accessing the variant_info of the inner map
             int ref_pos = variant_pos ;
-            std::string repeat = ref.substr(ref_pos + 1, 2) ;
+	    bool danger = false ;
 
+            std::string repeat = ref.substr(ref_pos + 1, 2) ;
             int i = 0 ;
             while ( i < 5 && (variant_info.Ref.length()>1 ||variant_info.Alt.length()>1) /*&& repeat[0]!=repeat[1]*/ ) {
-                if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2]) {
+                if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2] ) {
                     break ;
                 }
 
                 ref_pos = ref_pos + 2 ;
                 i++ ;
             }
+	    if ( i == 5 ) danger = true ;
 
-            if ( i == 5 ) {
+            if ( danger ) {
                 innerIter->second.is_danger = true ;
                 //std::cout << "danger pos:\t" << variant_pos+1 << "\n" ;
             }

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -343,8 +343,9 @@ std::map<int, RefAlt> SnpParser::getVariants_markindel(std::string chrName, cons
             int ref_pos = variant_pos ;
 	    bool danger = false ;
 
-            std::string repeat = ref.substr(ref_pos + 1, 2) ;
+            std::string repeat = ref.substr(ref_pos + 1, 2) ; // get the 2 words string in the reference which behind the indel position
             int i = 0 ;
+	    //check if there has 2 words tandem repeat in the reference
             while ( i < 5 && (variant_info.Ref.length()>1 ||variant_info.Alt.length()>1) /*&& repeat[0]!=repeat[1]*/ ) {
                 if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2] ) {
                     break ;
@@ -353,15 +354,11 @@ std::map<int, RefAlt> SnpParser::getVariants_markindel(std::string chrName, cons
                 ref_pos = ref_pos + 2 ;
                 i++ ;
             }
+
+	    // set the dnager to true if the repeat word repeats at least five times
 	    if ( i == 5 ) danger = true ;
 
-            if ( danger ) {
-                innerIter->second.is_danger = true ;
-                //std::cout << "danger pos:\t" << variant_pos+1 << "\n" ;
-            }
-            else {
-                innerIter->second.is_danger = false ;
-            }
+            innerIter->second.is_danger = danger ;
 
         }
 

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -18,6 +18,7 @@ struct RefAlt{
     std::string Alt;
     bool is_reverse;
     bool is_modify;
+    bool is_danger;
 };
 
 class FastaParser{
@@ -72,6 +73,8 @@ class SnpParser : public BaseVairantParser{
         ~SnpParser();
             
         std::map<int, RefAlt> getVariants(std::string chrName);  
+
+	std::map<int, RefAlt> getVariants_markindel(std::string chrName, const std::string &ref);
 
         std::vector<std::string> getChrVec();
         
@@ -180,7 +183,7 @@ class BamParser{
         void get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string, bool isONT);
    
     public:
-        BamParser(std::string chrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile);
+        BamParser(std::string chrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile, const std::string &ref_string);
         ~BamParser();
         
         void direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec , const std::string &ref_string);

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -252,6 +252,7 @@ std::pair<float,float> VairiantGraph::Onelongcase( std::vector<VoteResult> vote 
         }
     }
 
+    //if there has less than three variants use one read to vote we cncel the mechanism
     if ( counter <= 3 || (h1==0&&h2==0) ) {
         return std::make_pair( -1 , -1 ) ;
     }
@@ -339,7 +340,7 @@ void VairiantGraph::edgeConnectResult(){
         // check connect between surrent SNP and next n SNPs
         for(int i = 0 ; i < params->connectAdjacent ; i++ ){
 	    float weight = 1 ; 
-	    VoteResult vote ;
+	    VoteResult vote ; //used to store previous 20 variants' voting information
 	    vote.Pos = currPos ;
 
             // consider reads from the currnt SNP and the next (i+1)'s SNP

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -64,7 +64,7 @@ struct VariantEdge{
     // node pair 
     std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, float &weight, VoteResult &vote);
     // number of read of two node. AA and AB combination
-    std::pair<int,int> findNumberOfRead(int targetPos);
+    std::pair<float,float> findNumberOfRead(int targetPos);
 };
 
 

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -53,6 +53,8 @@ struct VoteResult{
     float weight;	//how much weight
     int hap;		//which haplotype 
     double ESR;		//similarity of para and cross
+
+    VoteResult( int currPos, float weight ) ;
 };
 
 struct VariantEdge{
@@ -62,7 +64,7 @@ struct VariantEdge{
 
     VariantEdge(int currPos);
     // node pair 
-    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, std::map<int,int> &variantType, float &weight, VoteResult &vote);
+    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, std::map<int,int> &variantType, VoteResult &vote);
     // number of read of two node. AA and AB combination
     std::pair<float,float> findNumberOfRead(int targetPos);
 };

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -45,6 +45,15 @@ class SubEdge{
 
 };
 
+//use to store the voting info from the previous variants
+struct VoteResult{
+    int Pos;		//who votes
+    float para;		//rr+aa
+    float cross;	//ra+ar
+    float weight;	//how much weight
+    int hap;		//which haplotype 
+    double ESR;		//similarity of para and cross
+};
 
 struct VariantEdge{
     int currPos;
@@ -53,7 +62,7 @@ struct VariantEdge{
 
     VariantEdge(int currPos);
     // node pair 
-    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, int &weight);
+    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, float &weight, VoteResult &vote);
     // number of read of two node. AA and AB combination
     std::pair<int,int> findNumberOfRead(int targetPos);
 };
@@ -88,7 +97,9 @@ class VairiantGraph{
         std::map<int,ReadBaseMap*> *totalVariantInfo;
         // position, type < 0=SNP 1=SV 2=MOD 3=INDEL >
         std::map<int,int> *variantType;
-        
+ 
+        std::pair<float,float> Onelongcase( std::vector<VoteResult> vote ) ;
+
         // phasing result     
         // PosAllele , block_start    
         std::map<PosAllele,int> *bkResult;

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -53,7 +53,7 @@ struct VariantEdge{
 
     VariantEdge(int currPos);
     // node pair 
-    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug);
+    std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug, int &weight);
     // number of read of two node. AA and AB combination
     std::pair<int,int> findNumberOfRead(int targetPos);
 };

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -95,10 +95,10 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
             continue;
         }
 
-        // create a bam parser object and prepare to fetch varint from each vcf file
-        BamParser *bamParser = new BamParser((*chrIter), params.bamFile, snpFile, svFile, modFile);
-        // fetch chromosome string
+	// fetch chromosome string
         std::string chr_reference = fastaParser.chrString.at(*chrIter);
+        // create a bam parser object and prepare to fetch varint from each vcf file
+        BamParser *bamParser = new BamParser((*chrIter), params.bamFile, snpFile, svFile, modFile, chr_reference);
         // use to store variant
         std::vector<ReadVariant> readVariantVec;
         // run fetch variant process


### PR DESCRIPTION
1. Add a function in the ParsingBam.cpp, which will use the reference string to mark the indel lies in the tandem repeat. The variants being marked, its variant type number will be set as 4 and their voting weight to the next 20 variants will change to 0.1 in the PhasingGraph.cpp

2. If the edgesimilarratio is lower than 0.1, we make its voting weight 20 times bigger. 

3. Add a struct "VoteResul"t in the PhasingGraph.h. And it will be used to store the voting info that the previous 20 variants provide.

4. Add a function called Onelongcase() in the PhasingGraph.cpp to deal with the SW case that One Long Read provides wrong information repeatedly

## SNP-only phasing 
### Switch error values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 1114 | 1216 | 1180 | 1205 | 1213 | 1197 |
| After modification | 1087 | 1196 | 1165 | 1176 | 1183 | 1177 |

### Block N50 values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 807537 | 1659260 | 2041009 | 2332195 | 2606645 | 2830210 |
| After modification | 807877 | 1671541 | 2043162 | 2353055 | 2642769 | 2838135 |


## SNP+INDEL cophasing 
### Switch error values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 1376 | 1386 | 1338 | 1340 | 1330 | 1335 |
| After modification | 1370 | 1356 | 1319 | 1323 | 1320 | 1305 |

### Block N50 values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 884383 | 1914050 | 2371120 | 2874966 | 3096618 | 3525021 |
| After modification | 901498 | 1933653 | 2487932 | 2930753 | 3227060 | 3612077 |
