### PR TITLE
Speed up remove overlap alignment

### DIFF
--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -576,9 +576,15 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
     // sort read index
     std::sort(delReadIdx.begin(), delReadIdx.end());
     // remove overlap alignment
-    for( int idx = delReadIdx.size() -1 ; idx > 0 ; idx-- ){
-        in_readVariant.erase( in_readVariant.begin() + delReadIdx[idx] );
+    delReadIdx.push_back((int)in_readVariant.size());
+    int saveIter = *(delReadIdx.begin());
+    for (auto delIter = delReadIdx.begin(), nextdelIter = std::next(delReadIdx.begin(), 1); nextdelIter != delReadIdx.end(); delIter++ , nextdelIter++) {
+        auto nowDelIter = *delIter+1;
+        while (nowDelIter<*nextdelIter){
+            in_readVariant[saveIter++]=in_readVariant[nowDelIter++];
+        }
     }
+    in_readVariant.erase( std::next(in_readVariant.begin(), saveIter), in_readVariant.end());
 
     int readCount=0;
     // merge alignment


### PR DESCRIPTION
### Modification erase vector method
![image](https://github.com/user-attachments/assets/761a2a2f-5a90-4787-8d52-c021dd816b8f)

### Time testing and result verification output
+ HG002 60x
  ```
  chrY    oldRemoveTime:0s        newRemoveTime:0s        Success
  chr19   oldRemoveTime:6s        newRemoveTime:0s        Success
  chr20   oldRemoveTime:6s        newRemoveTime:0s        Success
  chrX    oldRemoveTime:0s        newRemoveTime:0s        Success
  chr21   oldRemoveTime:3s        newRemoveTime:0s        Success
  chr22   oldRemoveTime:3s        newRemoveTime:0s        Success
  chr15   oldRemoveTime:10s       newRemoveTime:1s        Success
  chr14   oldRemoveTime:14s       newRemoveTime:0s        Success
  chr18   oldRemoveTime:11s       newRemoveTime:0s        Success
  chr16   oldRemoveTime:11s       newRemoveTime:1s        Success
  chr17   oldRemoveTime:15s       newRemoveTime:0s        Success
  chr13   oldRemoveTime:24s       newRemoveTime:0s        Success
  chr9    oldRemoveTime:35s       newRemoveTime:0s        Success
  chr10   oldRemoveTime:48s       newRemoveTime:0s        Success
  chr12   oldRemoveTime:52s       newRemoveTime:0s        Success
  chr11   oldRemoveTime:49s       newRemoveTime:0s        Success
  chr8    oldRemoveTime:56s       newRemoveTime:0s        Success
  chr6    oldRemoveTime:54s       newRemoveTime:1s        Success
  chr7    oldRemoveTime:73s       newRemoveTime:0s        Success
  chr5    oldRemoveTime:78s       newRemoveTime:0s        Success
  chr3    oldRemoveTime:72s       newRemoveTime:0s        Success
  chr4    oldRemoveTime:76s       newRemoveTime:0s        Success
  chr1    oldRemoveTime:101s      newRemoveTime:0s        Success
  chr2    oldRemoveTime:114s      newRemoveTime:0s        Success
  ``` 
+ HCC1395 75x
  ```
  chrY    oldRemoveTime:0s        newRemoveTime:0s        Success
  chr21   oldRemoveTime:2s        newRemoveTime:0s        Success
  chr19   oldRemoveTime:2s        newRemoveTime:0s        Success
  chrX    oldRemoveTime:1s        newRemoveTime:0s        Success
  chr13   oldRemoveTime:2s        newRemoveTime:0s        Success
  chr17   oldRemoveTime:0s        newRemoveTime:0s        Success
  chr18   oldRemoveTime:9s        newRemoveTime:0s        Success
  chr20   oldRemoveTime:11s       newRemoveTime:1s        Success
  chr15   oldRemoveTime:6s        newRemoveTime:0s        Success
  chr14   oldRemoveTime:7s        newRemoveTime:0s        Success
  chr11   oldRemoveTime:3s        newRemoveTime:0s        Success
  chr10   oldRemoveTime:3s        newRemoveTime:0s        Success
  chr12   oldRemoveTime:4s        newRemoveTime:0s        Success
  chr9    oldRemoveTime:11s       newRemoveTime:0s        Success
  chr16   oldRemoveTime:28s       newRemoveTime:0s        Success
  chr5    oldRemoveTime:11s       newRemoveTime:0s        Success
  chr22   oldRemoveTime:63s       newRemoveTime:0s        Success
  chr8    oldRemoveTime:1s        newRemoveTime:0s        Success
  chr6    oldRemoveTime:12s       newRemoveTime:0s        Success
  chr3    oldRemoveTime:7s        newRemoveTime:0s        Success
  chr1    oldRemoveTime:55s       newRemoveTime:1s        Success
  chr2    oldRemoveTime:31s       newRemoveTime:0s        Success
  chr7    oldRemoveTime:41s       newRemoveTime:0s        Success
  chr4    oldRemoveTime:179s      newRemoveTime:1s        Success
  ``` 

### Verify that the results are the same using the following code
```c++
    // Make a copy to verify the results
    std::vector<ReadVariant> in_readVariant_copy ;
    in_readVariant_copy.resize(in_readVariant.size());
    std::copy(in_readVariant.begin(), in_readVariant.end(), in_readVariant_copy.begin());

    // origin remove overlap alignment
    std::time_t oldRemoveTime = time(NULL);
    // fix 'idx >= 0'
    for( int idx = delReadIdx.size() -1 ; idx >= 0 ; idx-- ){
        in_readVariant.erase( in_readVariant.begin() + delReadIdx[idx] );
    }
    std::cerr << (*chr) << "\toldRemoveTime:" << difftime(time(NULL), oldRemoveTime) << "s";

    // new remove overlap alignment
    std::time_t newRemoveTime = time(NULL);
    delReadIdx.push_back((int)in_readVariant_copy.size());
    int saveIter = *(delReadIdx.begin());
    for (auto delIter = delReadIdx.begin(), nextdelIter = std::next(delReadIdx.begin(), 1); nextdelIter != delReadIdx.end(); delIter++ , nextdelIter++) {
        auto nowDelIter = *delIter+1;
        while (nowDelIter<*nextdelIter){
            in_readVariant_copy[saveIter++]=in_readVariant_copy[nowDelIter++];
        }
    }
    in_readVariant_copy.erase( std::next(in_readVariant_copy.begin(), saveIter), in_readVariant_copy.end());
    std::cerr <<"\tnewRemoveTime:" << difftime(time(NULL), newRemoveTime) << "s";

    // Verify the results
    if (in_readVariant_copy!=in_readVariant){
        std::cerr << "\tError\n";
    }
    else{
        std::cerr << "\tSuccess\n";
    }
``` 

+ add operator used for comparing results
  ```c++
  struct ReadVariant{
      // init function
      ReadVariant(): read_name(""), 
              mapping_quality(0), 
              source_id(""), 
              sample_id(""), 
              reference_start(0), 
              BX_tag(""){}
              
      std::string read_name;
      int mapping_quality;
      std::string source_id;
      std::string sample_id;
      int reference_start;
      std::string BX_tag;
      bool is_reverse;
      
      std::vector<Variant> variantVec;
      
      void sort();
      bool operator==(const ReadVariant& other) const {
          return read_name == other.read_name &&
                 mapping_quality == other.mapping_quality &&
                 source_id == other.source_id &&
                 sample_id == other.sample_id &&
                 reference_start == other.reference_start &&
                 BX_tag == other.BX_tag &&
                 is_reverse == other.is_reverse ;
      }
  };
  ``` 