### PR TITLE
Utilizing variant allele frequency and mismatch rate to reduce phasing errors caused by misaligned reads and miscalling variants.

### DIFF
--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -46,9 +46,7 @@ MethBamParser::~MethBamParser(){
     delete readStartEndMap;
 }
 
-void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec){
-    // init data structure and get core n
-    htsThreadPool threadPool = {NULL, 0};
+void MethBamParser::detectMeth(std::string chrName, int chr_len, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec){
 
     for( auto bamFile: params->bamFileVec ){
 
@@ -72,11 +70,7 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads,
 
         
         int result;
-        
-        // creat thread pool
-        if (!(threadPool.pool = hts_tpool_init(numThreads))) {
-            fprintf(stderr, "Error creating thread pool\n");
-        }
+
         hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
 
         while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) { 
@@ -99,7 +93,6 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, int numThreads,
         bam_hdr_destroy(bamHdr);
         bam_destroy1(aln);
         sam_close(fp_in);
-        hts_tpool_destroy(threadPool.pool);
     }
 }
 
@@ -536,10 +529,10 @@ void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
 
                 // this allele support ref
                 if( (*variant1Iter).allele == 0 )
-                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,0,1,false);
                 // this allele support alt
                 if( (*variant1Iter).allele == 1 )
-                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name);
+                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter),(*readIter).read_name,0,1,false);
                 
                 // next snp
                 variant2Iter++;

--- a/ModCallParsingBam.h
+++ b/ModCallParsingBam.h
@@ -87,7 +87,7 @@ class MethBamParser{
     public:
         MethBamParser(ModCallParameters &params, std::string &refString);
         ~MethBamParser();
-        void detectMeth(std::string chrName, int chr_len, int numThreads, std::vector<ReadVariant> &readVariantVec);
+        void detectMeth(std::string chrName, int chr_len, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec);
         void exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,int> &passPosition, std::ostringstream &methResult);
         void judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &fReadVariantVec, std::vector<ReadVariant> &rReadVariantVec );
         void calculateDepth();

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -11,21 +11,21 @@
 
 
 // FASTA
-FastaParser::FastaParser(std::string fastaFile ,  std::vector<std::string> chrName , std::vector<int> last_pos):
+FastaParser::FastaParser(std::string fastaFile,  std::vector<std::string> chrName, std::vector<int> last_pos, int numThreads):
     fastaFile(fastaFile),
     chrName(chrName),
     last_pos(last_pos)
 {
-    if(fastaFile==""){
-        for(std::vector<std::string>::iterator iter = chrName.begin() ; iter != chrName.end() ; iter++)
-            chrString.insert(std::make_pair( (*iter) , ""));
-        return;
-    }
-    
-    faidx_t *fai = NULL;
-    fai = fai_load(fastaFile.c_str());
+    // init map
+    for(std::vector<std::string>::iterator iter = chrName.begin() ; iter != chrName.end() ; iter++)
+        chrString.insert(std::make_pair( (*iter) , ""));
+
     // iterating all chr
+    #pragma omp parallel for schedule(dynamic) num_threads(numThreads)
     for(std::vector<std::string>::iterator iter = chrName.begin() ; iter != chrName.end() ; iter++){
+        
+        faidx_t *fai = NULL;
+        fai = fai_load(fastaFile.c_str());
         int index = iter - chrName.begin();
 
         // ref_len is a return value that is length of retrun string
@@ -35,8 +35,8 @@ FastaParser::FastaParser(std::string fastaFile ,  std::vector<std::string> chrNa
         if(ref_len == 0){
             std::cout<<"nothing in reference file \n";
         }
-        // insert to map
-        chrString.insert(std::make_pair( (*iter) , chr_info));
+        // update map
+        chrString[(*iter)] = chr_info;
 
     }
 }
@@ -365,13 +365,16 @@ void SnpParser::parserProcess(std::string &input){
 
 void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
     // header
-    if( input.find("#")!= std::string::npos){
+    if( input.substr(0, 2) == "##" ){
         // avoid double definition
-        if( input.find("ID=PS,")!= std::string::npos){
+        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
             ps_def = true;
         }
+        resultVcf << input << "\n";
+    }
+    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
         // format line 
-        if( input.find("##")== std::string::npos && commandLine == false){
+        if( commandLine == false ){
             if(ps_def == false){
                 resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
                 ps_def = true;
@@ -382,7 +385,7 @@ void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resul
         }
         resultVcf << input << "\n";
     }
-    else if( input.find("#")== std::string::npos ){
+    else{
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 
@@ -464,8 +467,11 @@ void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resul
             }   
         }
 
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+        
         // this pos is phase
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
             fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
@@ -633,10 +639,13 @@ SVParser::~SVParser(){
 }
 
 void SVParser::parserProcess(std::string &input){
-    if( input.find("#")!= std::string::npos){
+    if( input.substr(0, 2) == "##" ){
 
     }
-    else if( input.find("#")== std::string::npos ){
+    else if ( input.substr(0, 1) == "#" ){
+        
+    }
+    else{
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 
@@ -729,13 +738,16 @@ void SVParser::writeResult(PhasingResult phasingResult){
 
 void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
     // header
-    if( input.find("#")!= std::string::npos){
+    if( input.substr(0, 2) == "##" ){
         // avoid double definition
-        if( input.find("ID=PS,")!= std::string::npos){
+        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
             ps_def = true;
         }
+        resultVcf << input << "\n";
+    }
+    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
         // format line 
-        if( input.find("##")== std::string::npos && commandLine == false){
+        if( commandLine == false ){
             if(ps_def == false){
                 resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
                 ps_def = true;
@@ -746,7 +758,7 @@ void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &result
         }
         resultVcf << input << "\n";
     }
-    else if( input.find("#")== std::string::npos ){
+    else{
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 
@@ -829,9 +841,12 @@ void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &result
                 fields[9][modify_start+1] = '/';
             }        
         }
-                
+        
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+        
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";
@@ -873,7 +888,19 @@ void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &result
         resultVcf << "\n";
     }
 }
-
+bool SVParser::findSV(std::string chr, int position){
+    std::map<std::string, std::map<int, std::map<std::string ,bool> > >::iterator chrIter = chrVariant->find(chr);
+    // empty chromosome
+    if( chrIter == chrVariant->end() )
+        return false;
+    
+    std::map<int, std::map<std::string ,bool>>::iterator posIter = (*chrVariant)[chr].find(position);
+    // empty position
+    if( posIter == (*chrVariant)[chr].end() )
+        return false;
+        
+    return true;
+}
 BamParser::BamParser(std::string inputChrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile):chrName(inputChrName),BamFileVec(inputBamFileVec){
     
     currentVariants = new std::map<int, RefAlt>;
@@ -903,7 +930,7 @@ BamParser::~BamParser(){
     delete currentMod;
 }
 
-void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string){
+void BamParser::direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string){
     
     // record SNP start iter
     std::map<int, RefAlt>::iterator tmpFirstVariantIter = firstVariantIter;
@@ -917,9 +944,7 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
         firstVariantIter = tmpFirstVariantIter;
         firstSVIter = tmpFirstSVIter;
         firstModIter = tmpFirstModIter;
-              
-        // init data structure and get core n
-        htsThreadPool threadPool = {NULL, 0};
+
         // open bam file
         samFile *fp_in = hts_open(bamFile.c_str(),"r"); 
         // load reference file
@@ -939,14 +964,8 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
         hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
 
         
-        int result;
-        
-        // creat thread pool
-        if (!(threadPool.pool = hts_tpool_init(numThreads))) {
-            fprintf(stderr, "Error creating thread pool\n");
-        }
         hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
-        
+        int result;
         while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) { 
             int flag = aln->core.flag;
 
@@ -961,18 +980,17 @@ void BamParser::direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingPa
                 continue;
             }
 
-            get_snp(*bamHdr,*aln,readVariantVec, ref_string, params.isONT);
+            get_snp(*bamHdr,*aln,readVariantVec, ref_string, params.isONT, params.mismatchRate);
         }
         hts_idx_destroy(idx);
         bam_hdr_destroy(bamHdr);
         bam_destroy1(aln);
         sam_close(fp_in);
-        hts_tpool_destroy(threadPool.pool);
     }
     
 }
 
-void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec,const std::string &ref_string, bool isONT){
+void BamParser::get_snp(const bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string, bool isONT, double mismatchRate){
 
     ReadVariant *tmpReadResult = new ReadVariant();
     (*tmpReadResult).read_name = bam_get_qname(&aln);
@@ -980,24 +998,23 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
     (*tmpReadResult).reference_start = aln.core.pos;
     (*tmpReadResult).is_reverse = bam_is_rev(&aln);
     
-    // Skip variants that are to the left of this read
-    while( firstVariantIter != currentVariants->end() && (*firstVariantIter).first < aln.core.pos )
-        firstVariantIter++;
-    
-    // Skip structure variants that are to the left of this read
-    while( firstSVIter != currentSV->end() && (*firstSVIter).first < aln.core.pos )
-        firstSVIter++;
-    
-    // Skip modify that are to the left of this read
-    while( firstModIter != currentMod->end() && (*firstModIter).first < aln.core.pos )
-        firstModIter++;
-    
     // position relative to reference
     int ref_pos = aln.core.pos;
 
     // position relative to read
     int query_pos = 0;
-    // translation char* to string;
+    
+    // Skip variants that are to the left of this read
+    while( firstVariantIter != currentVariants->end() && (*firstVariantIter).first < ref_pos )
+        firstVariantIter++;
+    
+    // Skip structure variants that are to the left of this read
+    while( firstSVIter != currentSV->end() && (*firstSVIter).first < ref_pos )
+        firstSVIter++;
+    
+    // Skip modify that are to the left of this read
+    while( firstModIter != currentMod->end() && (*firstModIter).first < ref_pos )
+        firstModIter++;
 
     // set variant start for current alignment
     std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
@@ -1008,148 +1025,194 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
     // set modify start for current alignment
     std::map<int, std::map<std::string ,RefAlt> >::iterator currentModIter = firstModIter;
 
+    // set cigar pointer and number of cigar
     uint32_t *cigar = bam_get_cigar(&aln);
-    // reading cigar to detect snp on this read
     int aln_core_n_cigar = aln.core.n_cigar;
+    uint8_t* nm_tag = bam_aux_get(&aln, "NM");
+    int nm_value = bam_aux2i(nm_tag);
+    
+    int cigar_del_oplen = 0;
+    int cigar_indel_oplen = 0;
+    int cigar_clip_oplen = 0;
+    int cigar_total_oplen = 0;
+    //int pushread = 0;
+    //int giveupread = 0;
+    
+    // reading cigar to detect varaint on this read
     for(int i = 0; i < aln_core_n_cigar ; i++ ){
-        int cigar_op = bam_cigar_op(cigar[i]);
-        int length   = bam_cigar_oplen(cigar[i]);
         
-        // iterator next modify
-        while( currentModIter != currentMod->end() && (*currentModIter).first < ref_pos ){
-            // check this read contain modify
-            std::map<std::string ,RefAlt>::iterator readIter = (*currentModIter).second.find(bam_get_qname(&aln));
-            if( readIter != (*currentModIter).second.end() && (*currentModIter).first < (*currentVariantIter).first){
-                // check varaint strand in vcf file is same as bam file
-                if( (*readIter).second.is_reverse == bam_is_rev(&aln) ){
-                    // -2 : forward strand
-                    // -3 : reverse strand
-                    int strand = ( bam_is_rev(&aln) ? -3 : -2);
-                    int allele = ((*readIter).second.is_modify ? 0 : 1) ;
-                    Variant *tmpVariant = new Variant((*currentModIter).first, allele, strand );
-                    // push mod into result vector
-                    (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                    delete tmpVariant;
-                }
-            }
-            currentModIter++;
+        // get current cigar type and cigar length
+        int cigar_op = bam_cigar_op(cigar[i]);
+        int cigar_oplen = bam_cigar_oplen(cigar[i]);
+        
+        
+        // get the starting position of each variant currently.
+        int modPos = (*currentModIter).first;
+        int svPos = (*currentSVIter).first;
+        int variantPos = (*currentVariantIter).first;
+        
+        // get the first variant detected by the alignment.
+        while( currentVariantIter != currentVariants->end() && variantPos < ref_pos ){
+            currentVariantIter++;
+            variantPos = (*currentVariantIter).first;
         }
-
-        // iterator next SV
-        while( currentSVIter != currentSV->end() && (*currentSVIter).first < ref_pos ){
-            if( (*currentSVIter).first < (*currentVariantIter).first ){
-                std::map<std::string ,bool>::iterator readIter = (*currentSV)[(*currentSVIter).first].find(bam_get_qname(&aln));
+        
+        // Processing the region covered by the current CIGAR operator
+        // Determine if any variant is included in the current CIGAR operator
+        while( ( currentModIter     != currentMod->end()      && modPos     < ref_pos + cigar_oplen ) || 
+               ( currentSVIter      != currentSV->end()       && svPos      < ref_pos + cigar_oplen ) || 
+               ( currentVariantIter != currentVariants->end() && variantPos < ref_pos + cigar_oplen )){
+            
+            // modification's position is minimal
+            if( ( currentVariantIter == currentVariants->end() || modPos < variantPos ) &&
+                ( currentSVIter      == currentSV->end()       || modPos < svPos ) &&
+                  currentModIter     != currentMod->end() ){
+                
+                // check this read contain modification
+                std::map<std::string ,RefAlt>::iterator readIter = (*currentModIter).second.find(bam_get_qname(&aln));
+                if( readIter != (*currentModIter).second.end() && modPos < variantPos ){
+                    
+                    // check varaint strand in vcf file is same as bam file
+                    if( (*readIter).second.is_reverse == bam_is_rev(&aln) ){
+                        // -2 : forward strand
+                        // -3 : reverse strand
+                        int strand = ( bam_is_rev(&aln) ? -3 : -2);
+                        int allele = ((*readIter).second.is_modify ? 0 : 1) ;
+                        Variant *tmpVariant = new Variant(modPos, allele, strand );
+                        // push mod into result vector
+                        (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
+                        delete tmpVariant;
+                    }
+                }
+                currentModIter++;
+                modPos = (*currentModIter).first;
+            }
+            // SV's position is minimal
+            else if( ( currentVariantIter == currentVariants->end() || svPos < variantPos ) &&
+                     ( currentModIter     == currentMod->end()      || svPos < modPos ) &&
+                       currentSVIter      != currentSV->end()){
+                        
+                std::map<std::string ,bool>::iterator readIter = (*currentSV)[svPos].find(bam_get_qname(&aln));
                 // If this read not contain SV, it means this read is the same as reference genome.
                 // default this read the same as ref
                 int allele = 0; 
                 // this read contain SV.
-                if( readIter != (*currentSV)[(*currentSVIter).first].end() ){
+                if( readIter != (*currentSV)[svPos].end() ){
                     allele = 1;
                 }
                 // use quality -1 to identify SVs
                 // push this SV to vector
-                Variant *tmpVariant = new Variant((*currentSVIter).first, allele, -1 );
+                Variant *tmpVariant = new Variant(svPos, allele, -1 );
                 (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
                 delete tmpVariant;
-            }  
-            // next SV iter 
-            currentSVIter++;
+                // next SV iter 
+                currentSVIter++;
+                svPos = (*currentSVIter).first;
+            }
+
+            // SNP's position is minimal
+            else if( ( currentSVIter      == currentSV->end()  || variantPos < svPos ) &&
+                     ( currentModIter     == currentMod->end() || variantPos < modPos ) &&
+                       currentVariantIter != currentVariants->end() ){
+                
+                // CIGAR operators: MIDNSHP=X correspond 012345678
+                // 0: alignment match (can be a sequence match or mismatch)
+                // 7: sequence match
+                // 8: sequence mismatch                
+                if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
+                    int refAlleleLen = (*currentVariantIter).second.Ref.length();
+                    int altAlleleLen = (*currentVariantIter).second.Alt.length();
+                    int offset = variantPos - ref_pos;
+                    int base_q = 0;
+                    int allele = -1;
+                    
+                    // The position of the variant exceeds the length of the read.
+                    if( query_pos + offset + 1 > int(aln.core.l_qseq) ){
+                        return;
+                    }
+
+                    // SNP
+                    if( refAlleleLen == 1 && altAlleleLen == 1){
+                        char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos + offset)];
+                        if(base == (*currentVariantIter).second.Ref[0])
+                            allele = 0;
+                        else if(base == (*currentVariantIter).second.Alt[0])
+                            allele = 1;
+
+                        base_q = bam_get_qual(&aln)[query_pos + offset];
+                    } 
+            
+                    // insertion
+                    //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
+                    if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
+                
+                        // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
+                
+                        // uint8_t *qstring = bam_get_seq(aln); 
+                        // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
+                        // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
+
+                        if ( ref_pos + cigar_oplen - 1 == variantPos && bam_cigar_op(cigar[i+1]) == 1 ) {
+                            allele = 1 ;
+                        }
+                        else {
+                            allele = 0 ;
+                        }
+                        // using this quality to identify indel
+                        base_q = -4;
+                    } 
+            
+                    // deletion
+                    //if( refAlleleLen != 1 && altAlleleLen == 1 && align.op[i+1] == 2 && i+1 < align.cigar_len){
+                    if( refAlleleLen != 1 && altAlleleLen == 1 && i+1 < aln_core_n_cigar) {
+
+                        if ( ref_pos + cigar_oplen - 1 == variantPos && bam_cigar_op(cigar[i+1]) == 2 ) {
+                            allele = 1 ;
+                        }
+                        else {
+                            allele = 0 ;
+                        }
+                        // using this quality to identify indel
+                        base_q = -4;
+                    } 
+            
+                    if( allele != -1 ){
+                        // record snp result
+                        Variant *tmpVariant = new Variant(variantPos, allele, base_q);
+                        (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
+                        delete tmpVariant;                        
+                    }
+                    currentVariantIter++;
+                    variantPos = (*currentVariantIter).first;
+                }
+                else break;
+            }
         }
         
-        // iterator next variant
-        while( currentVariantIter != currentVariants->end() && (*currentVariantIter).first < ref_pos ){
-            currentVariantIter++;
-        }
+        // Preparing to process the next CIGAR operator.
         
         // CIGAR operators: MIDNSHP=X correspond 012345678
         // 0: alignment match (can be a sequence match or mismatch)
         // 7: sequence match
         // 8: sequence mismatch
         if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
-            
-            while( currentVariantIter != currentVariants->end() && (*currentVariantIter).first < ref_pos + length){
-
-                int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                int offset = (*currentVariantIter).first - ref_pos;
-                int base_q = 0;
-
-                if( query_pos + offset + 1 > int(aln.core.l_qseq) ){
-                    return;
-                }
-
-                int allele = -1;
-                
-                // SNP
-                if( refAlleleLen == 1 && altAlleleLen == 1){
-                    char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos + offset)];
-                    if(base == (*currentVariantIter).second.Ref[0])
-                        allele = 0;
-                    else if(base == (*currentVariantIter).second.Alt[0])
-                        allele = 1;
-                    
-                    base_q = bam_get_qual(&aln)[query_pos + offset];
-                } 
-                
-                // insertion
-                //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
-                if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
-                    
-                    // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
-                    
-                    // uint8_t *qstring = bam_get_seq(aln); 
-                    // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
-                    // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
-
-                    if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 1 ) {
-                        allele = 1 ;
-                    }
-                    else {
-                        allele = 0 ;
-                    }
-                    // using this quality to identify indel
-                    base_q = -4;
-                } 
-                
-                // deletion
-                //if( refAlleleLen != 1 && altAlleleLen == 1 && align.op[i+1] == 2 && i+1 < align.cigar_len){
-                if( refAlleleLen != 1 && altAlleleLen == 1 && i+1 < aln_core_n_cigar) {
-
-                    if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 2 ) {
-                        allele = 1 ;
-                    }
-                    else {
-                        allele = 0 ;
-                    }
-                    // using this quality to identify indel
-                    base_q = -4;
-                } 
-                
-                if( allele != -1 ){
-                    // record snp result
-                    Variant *tmpVariant = new Variant((*currentVariantIter).first, allele, base_q);
-                    (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                    delete tmpVariant;
-                }
-                currentVariantIter++;
-            }
-            
-            query_pos += length;
-            ref_pos += length;
+            query_pos += cigar_oplen;
+            ref_pos += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
         }
         // 1: insertion to the reference
         else if( cigar_op == 1 ){
-            query_pos += length;
+            query_pos += cigar_oplen;
+            cigar_indel_oplen += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
         }
-        // 2: deletion from the reference
         else if( cigar_op == 2 ){
             
             // If a reference is given
             // it will determine whether the SNP falls in the homopolymer
             // and start the processing of the SNP fall in the alignment GAP
-            
-            if(ref_string != "" && isONT){
-                int del_len = length;
+            if(ref_string != ""){
+                int del_len = cigar_oplen;
                 if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
                     //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
                         // special case
@@ -1172,28 +1235,32 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                         if( refAlleleLen == 1 && altAlleleLen == 1){
                             // get the next match
                             char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
-                            if( base == (*currentVariantIter).second.Ref[0] )
+                            if( base == (*currentVariantIter).second.Ref[0] ){
                                 allele = 0;
-                            else if( base == (*currentVariantIter).second.Alt[0] )
+                            }
+                            else if( base == (*currentVariantIter).second.Alt[0] ){
                                 allele = 1;
-                            
+                            }
                             base_q = bam_get_qual(&aln)[query_pos];
                         }
-                        
                         // the read deletion contain VCF's deletion
-                        if( refAlleleLen != 1 && altAlleleLen == 1){
-                            //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
-                            //std::string refSeq = (*currentVariantIter).second.Ref;
-                            //std::string altSeq = (*currentVariantIter).second.Alt;
+                        else if( refAlleleLen != 1 && altAlleleLen == 1 ){
 
-                            allele = 1;
-                            // using this quality to identify indel
-                            base_q = -4;
-                        }
-                        else if ( allele == -1 ) {
-                            allele = 0;
-                            // using this quality to identify indel
-                            base_q = -4;
+                            if( refAlleleLen != 1 && altAlleleLen == 1){
+                                //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
+                                //std::string refSeq = (*currentVariantIter).second.Ref;
+                                //std::string altSeq = (*currentVariantIter).second.Alt;
+
+                                allele = 1;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            else if ( allele == -1 ) {
+                                allele = 0;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            
                         }
                         
                         if(allele != -1){
@@ -1202,39 +1269,63 @@ void BamParser::get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<
                             currentVariantIter++;
                             delete tmpVariant;
                         }
-                        
+
                     }
                 }
             }
-            ref_pos += length;
+            ref_pos += cigar_oplen;
+            cigar_del_oplen += cigar_oplen;
+            cigar_indel_oplen += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
         }
         // 3: skipped region from the reference
         else if( cigar_op == 3 ){
-            ref_pos += length;
+            ref_pos += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
         }
         // 4: soft clipping (clipped sequences present in SEQ)
         else if( cigar_op == 4 ){
-            query_pos += length;
+            query_pos += cigar_oplen;
+            cigar_clip_oplen += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
         }
         // 5: hard clipping (clipped sequences NOT present in SEQ)
         // 6: padding (silent deletion from padded reference)
-        else if( cigar_op == 5 || cigar_op == 6 ){
-            // do nothing
+        else if( cigar_op == 5 ){
+            cigar_clip_oplen += cigar_oplen;
+            cigar_total_oplen += cigar_oplen;
+        }
+        else if(cigar_op == 6 ){
+            cigar_total_oplen += cigar_oplen;
         }
         else{
             std::cerr<< "alignment find unsupported CIGAR operation from read: " << bam_get_qname(&aln) << "\n";
             exit(1);
         }
     }
-    if( (*tmpReadResult).variantVec.size() > 0 )
-        readVariantVec.push_back((*tmpReadResult));
+    int num_of_mismatch = nm_value - cigar_indel_oplen;
+    int length = cigar_total_oplen - cigar_clip_oplen - cigar_del_oplen;
+    double mmrate = ((float)num_of_mismatch / (float)length)*100;
+    if( mmrate > mismatchRate ){ 
+      (*tmpReadResult).fakeRead = true;
+    }
+    else{
+      (*tmpReadResult).fakeRead = false;
+    }
+    //float error_rate = nm_value / length;
     
+    if( (*tmpReadResult).variantVec.size() > 0 )
+      readVariantVec.push_back((*tmpReadResult));
+    
+    //std::cout<< "readname: " << bam_get_qname(&aln) << "\tnm_value: " << nm_value << "\tcigar_total_oplen: " << cigar_total_oplen << "\tcigar_clip_oplen: " << cigar_clip_oplen << "\tcigar_indel_oplen: " << cigar_indel_oplen << "\tmm_rate: " << mm_rate << "\n";
+    //std::cout << bamHdr.target_name[aln.core.tid] << "\treadname: " << bam_get_qname(&aln) << "\t" << mmrate << "\n";
     delete tmpReadResult;
 }
 
-METHParser::METHParser(PhasingParameters &in_params, SnpParser &in_snpFile):commandLine(false){
+METHParser::METHParser(PhasingParameters &in_params, SnpParser &in_snpFile, SVParser &in_svFile):commandLine(false){
 	params = &in_params;
     snpFile = &in_snpFile;
+    svFile = &in_svFile;
     representativePos=-1;
     upMethPos = -1;
     
@@ -1271,7 +1362,7 @@ METHParser::~METHParser(){
 
 void METHParser::parserProcess(std::string &input){
     // header
-    if( input.find("#")== std::string::npos ){
+    if( input.substr(0, 1) != "#" ){
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 
@@ -1313,8 +1404,8 @@ void METHParser::parserProcess(std::string &input){
             return;
         }
         
-        // conflict pos with SNP
-        if( (*snpFile).findSNP(chr,pos) ){
+        // conflict pos with SNP and SV
+        if( (*snpFile).findSNP(chr,pos) || (*svFile).findSV(chr,pos) ){
             return;
         }
         
@@ -1374,13 +1465,16 @@ void METHParser::parserProcess(std::string &input){
 
 void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
     // header
-    if( input.find("#")!= std::string::npos){
+    if( input.substr(0, 2) == "##" ){
         // avoid double definition
-        if( input.find("ID=PS,")!= std::string::npos){
+        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
             ps_def = true;
         }
+        resultVcf << input << "\n";
+    }
+    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
         // format line 
-        if( input.find("##")== std::string::npos && commandLine == false){
+        if( commandLine == false ){
             if(ps_def == false){
                 resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
                 ps_def = true;
@@ -1391,7 +1485,7 @@ void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resu
         }
         resultVcf << input << "\n";
     }
-    else if( input.find("#")== std::string::npos ){
+    else{
         std::istringstream iss(input);
         std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
 
@@ -1476,9 +1570,12 @@ void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resu
                 fields[9][modify_start+1] = '/';
             }        
         }
-                
+        
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx); 
+        
         // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() ){
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
                     
             // add PS flag and value
             fields[8] = fields[8] + ":PS";

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -27,7 +27,7 @@ class FastaParser{
         std::vector<std::string> chrName;
         std::vector<int> last_pos;
     public:
-        FastaParser(std::string fastaFile  , std::vector<std::string> chrName , std::vector<int> last_pos);
+        FastaParser(std::string fastaFile, std::vector<std::string> chrName, std::vector<int> last_pos, int numThreads);
         ~FastaParser();
         
         // chrName, chr string
@@ -112,6 +112,8 @@ class SVParser : public BaseVairantParser{
         std::map<int, std::map<std::string ,bool> > getVariants(std::string chrName);  
 
         void writeResult(PhasingResult phasingResult);
+
+        bool findSV(std::string chr, int posistion);
 };
 
 class METHParser : public BaseVairantParser{
@@ -119,6 +121,7 @@ class METHParser : public BaseVairantParser{
     private:
         PhasingParameters *params;
         SnpParser *snpFile;
+        SVParser *svFile;
         
         int representativePos;
         int upMethPos;
@@ -141,7 +144,7 @@ class METHParser : public BaseVairantParser{
         
         std::map<int, std::map<std::string ,RefAlt> > getVariants(std::string chrName);  
         
-        METHParser(PhasingParameters &params, SnpParser &snpFile);
+        METHParser(PhasingParameters &params, SnpParser &snpFile, SVParser &svFile);
         ~METHParser();
 		
 		void writeResult(PhasingResult phasingResult);
@@ -174,13 +177,13 @@ class BamParser{
         // mod map and iter
         std::map<int, std::map<std::string ,RefAlt> > *currentMod;
         std::map<int, std::map<std::string ,RefAlt> >::iterator firstModIter;
-        void get_snp(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string, bool isONT);
+        void get_snp(const bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, const std::string &ref_string, bool isONT, double mismatchRate);
    
     public:
         BamParser(std::string chrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile);
         ~BamParser();
         
-        void direct_detect_alleles(int lastSNPPos, int &numThreads, PhasingParameters params, std::vector<ReadVariant> &readVariantVec , const std::string &ref_string);
+        void direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec , const std::string &ref_string);
 
 };
 

--- a/Phasing.cpp
+++ b/Phasing.cpp
@@ -31,7 +31,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 "   -p, --baseQuality=[0~90]               change edge's weight to --edgeWeight if base quality is lower than the threshold. default:12\n"
 "   -e, --edgeWeight=[0~1]                 if one of the bases connected by the edge has a quality lower than --baseQuality\n"
 "                                          its weight is reduced from the normal 1. default:0.1\n"
-"   -a, --connectAdjacent=Num              connect adjacent N SNPs. default:20\n"
+"   -a, --connectAdjacent=Num              connect adjacent N SNPs. default:35\n"
 "   -d, --distance=Num                     phasing two variant if distance less than threshold. default:300000\n"
 "   -1, --edgeThreshold=[0~1]              give up SNP-SNP phasing pair if the number of reads of the \n"
 "                                          two combinations are similar. default:0.7\n"
@@ -90,7 +90,7 @@ namespace opt
     static bool isPB=false;
     static bool phaseIndel=false;
     
-    static int connectAdjacent = 20;
+    static int connectAdjacent = 35;
     static int mappingQuality = 1;
     static double mismatchRate = 3;
     

--- a/Phasing.cpp
+++ b/Phasing.cpp
@@ -25,7 +25,7 @@ static const char *CORRECT_USAGE_MESSAGE =
 
 "parse alignment arguments:\n"
 "   -q, --mappingQuality=Num               filter alignment if mapping quality is lower than threshold. default:1\n"
-"   -x, --mismatchRate=Num                 mark reads as false if mismatchRate of them are lower than threshold. default:3\n\n"
+"   -x, --mismatchRate=Num                 mark reads as false if mismatchRate of them are higher than threshold. default:3\n\n"
 
 "phasing graph arguments:\n"
 "   -p, --baseQuality=[0~90]               change edge's weight to --edgeWeight if base quality is lower than the threshold. default:12\n"

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -32,7 +32,7 @@ class SubEdge{
         
         void destroy();
         
-        void addSubEdge(int currentQuality, Variant connectNode, std::string readName);
+        void addSubEdge(int currentQuality, Variant connectNode, std::string readName, int baseQuality, double edgeWeight,bool fakeRead);
         std::pair<float,float> BestPair(int targetPos);
         float getRefReadCount(int targetPos);
         float getAltReadCount(int targetPos);        
@@ -50,12 +50,19 @@ struct VariantEdge{
     int currPos;
     SubEdge* alt;
     SubEdge* ref;
-
+    int refcnt ;
+    int altcnt ;
+    double vaf ;
+    int coverage ;
+    int vaf_fake_count ;
+    
     VariantEdge(int currPos);
     // node pair 
     std::pair<PosAllele,PosAllele> findBestEdgePair(int targetPos, bool isONT, double diffRatioThreshold, bool debug);
     // number of read of two node. AA and AB combination
     std::pair<int,int> findNumberOfRead(int targetPos);
+    bool get_fakeSnp();
+    
 };
 
 
@@ -107,10 +114,10 @@ class VairiantGraph{
 
     public:
     
-        VairiantGraph(std::string &ref, PhasingParameters &params);
+        VairiantGraph(std::string &ref, PhasingParameters &params, SnpParser &snpFile, std::string chrName);
         ~VairiantGraph();
     
-        void addEdge(std::vector<ReadVariant> &in_readVariant);
+        void addEdge(std::vector<ReadVariant> &in_readVariant, SnpParser &snpFile, std::string chrName);
         
         void phasingProcess();
         void writingDotFile(std::string dotPrefix);

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -61,11 +61,10 @@ struct VariantEdge{
     int currPos;
     SubEdge* alt;
     SubEdge* ref;
-    int refcnt ;
-    int altcnt ;
-    double vaf ;
-    int coverage ;
-    int vaf_fake_count ;
+    int refcnt ; // count the ref base amount
+    int altcnt ; // count the alt base amount
+    double vaf ; // count the vaf of the left snp
+    int coverage ; // count the coverge on the snp
     
     VariantEdge(int currPos);
     // node pair 
@@ -126,7 +125,7 @@ class VairiantGraph{
 
     public:
     
-        VairiantGraph(std::string &ref, PhasingParameters &params, SnpParser &snpFile, std::string chrName);
+        VairiantGraph(std::string &ref, PhasingParameters &params);
         ~VairiantGraph();
     
         void addEdge(std::vector<ReadVariant> &in_readVariant);

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -26,6 +26,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
     std::cerr<< "Distance Threshold : " << params.distance        << "\n";
     std::cerr<< "Connect Adjacent   : " << params.connectAdjacent << "\n";
     std::cerr<< "Edge Threshold     : " << params.edgeThreshold   << "\n";
+    std::cerr<< "Overlap Threshold  : " << params.overlapThreshold   << "\n";
     std::cerr<< "Mapping Quality    : " << params.mappingQuality  << "\n";
     std::cerr<< "Mismatch Rate      : " << params.mismatchRate  << "\n";
     std::cerr<< "Variant Confidence : " << params.snpConfidence   << "\n";
@@ -118,7 +119,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
         }
         
         // create a graph object and prepare to phasing.
-        VairiantGraph *vGraph = new VairiantGraph(chr_reference, params, snpFile, (*chrIter));
+        VairiantGraph *vGraph = new VairiantGraph(chr_reference, params);
         // trans read-snp info to edge info
         vGraph->addEdge(readVariantVec);
         // run main algorithm

--- a/PhasingProcess.h
+++ b/PhasingProcess.h
@@ -21,7 +21,13 @@ struct PhasingParameters
     
     int connectAdjacent;
     int mappingQuality;
-
+    double mismatchRate;
+    
+    int baseQuality;
+    double edgeWeight;
+    //double falseWeight;
+    //int coverageThreshold;
+    
     double snpConfidence;
     double readConfidence;
     

--- a/Util.cpp
+++ b/Util.cpp
@@ -11,44 +11,6 @@ void mergeAllChrPhasingResult(const ChrPhasingResult& allChrPhasingResults, Phas
     }
 }
 
-void setPhasingNumThreads(const int& defaultChrThreads,const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads){
-    if(availableThreads == 0){
-        // The default thread value is 0, indicating that each chromosome concurrently utilizes 
-        // a single thread for computation. Due to the limited multithreading acceleration space 
-        // in htslib and an average utilization of no more than 5 threads per chromosome, the 
-        // default value is set to 5.
-        chrNumThreads = defaultChrThreads;
-        bamParserNumThreads = 5;
-    }
-    else if( defaultChrThreads > availableThreads){
-        // Due to the number of available threads being less than the number of chromosomes, 
-        // processing is performed on a subset of chromosomes equal to the availableThreads count, 
-        // with a limitation on the number of threads for reading the BAM file for each chromosome.
-        chrNumThreads = availableThreads;
-        bamParserNumThreads = 1;
-    }
-    else{
-        // If the number of available threads exceeds the count of chromosomes, the surplus 
-        // threads will be utilized to accelerate the speed of htslib in parsing BAM files.
-        chrNumThreads = defaultChrThreads;
-        bamParserNumThreads = std::max(1,availableThreads/defaultChrThreads);
-    }
-}
-
-void setModcallNumThreads(const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads){
-    // Using 4 threads in htslib tends to yield higher utilization.
-    // Allocate threads to the BAM parser, but do not exceed the maximum number of threads.
-    // This ensures that, even when more threads are available, the BAM parser does not use too many,
-    // thereby leaving resources available for other tasks.
-    const int maxBamParserThreads = 4;
-    bamParserNumThreads = std::min(maxBamParserThreads, availableThreads);
-
-    // Allocate at least one thread to the chromosome processing task.
-    // If there are enough available threads, the remaining threads will be allocated to this task.
-    // This allocation maintains a balance in the total number of threads used.
-    chrNumThreads = std::max(1, availableThreads / bamParserNumThreads);
-}
-
 std::string getTargetString(std::string line, std::string start_sign, std::string end_sign){
     int start = line.find(start_sign) + 1;
     int end   = line.find(end_sign);

--- a/Util.h
+++ b/Util.h
@@ -80,6 +80,7 @@ struct ReadVariant{
     int reference_start;
     std::string BX_tag;
     bool is_reverse;
+    bool fakeRead;
     
     std::vector<Variant> variantVec;
     


### PR DESCRIPTION
**1. ParsingBam.cpp:** The get_snp() function now uses the CIGAR string to calculate mirages and employs the mismatch rate (mmrate) to determine if a read is likely misaligned, flagged by setting the fakeRead boolean.

**2. PhasingGraph.cpp:** 
    **addEdge() Function:** the reference and alternate base counts for each variant are now recorded.
    **addSubEdge() Function:** If a read is identified as a fakeRead, its weight is reduced to 0.01.
    **edgeConnectResult() Function:** The variant allele frequency (VAF) is calculated using the reference and alternate base counts. If the VAF equals 0 or 1, the variant is considered miscalled, and its voting weight is reduced to 0.01.
    **readCorrection() Function:** VAF and the fakeRead flag are also used to identify fake variants or misaligned reads. If a variant is identified as fake, its tagging weight is reduced to 0.01; similarly, the phasing weight of a fake read is also reduced to 0.01.

**3. Phasing.cpp:** 
    **--connectAdjacent:** original default is 20, now change to 35.

## SNP-only phasing 
### Switch error values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 1,087 | 1,196 | 1,165 | 1,176 | 1,183 | 1,177 |
| After modification | 1,111 | 1,159 | 1,137 | 1,167 | 1,169 | 1,172 |

### Block N50 values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 807,877 | 1,671,541 | 2,043,162 | 2,353,055 | 2,642,769 | 2,838,135 |
| After modification | 809,479 | 1,671,541 | 2,043,162 | 2,358,484 | 2,655,322 | 2,858,299 |


## SNP+INDEL cophasing 
### Switch error values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 1,370 | 1,356 | 1,319 | 1,323 | 1,320 | 1,305 |
| After modification | 1,383 | 1,306 | 1,295 | 1,301 | 1,301 | 1,298 |

### Block N50 values
| ---  | 10x | 20x | 30x | 40x | 50x | 60x |
| --- | --- | --- | --- | --- | --- | --- | 
| Before modification | 901,498 | 1,933,653 | 2,487,932 | 2,930,753 | 3,227,060 | 3,612,077 |
| After modification | 901,697 | 1,926,974 | 2,483,519 | 2,922,137 | 3,227,302 | 3,612,077 |
