### PR TITLE
Revise new block conditions

### DIFF
--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -258,7 +258,7 @@ void VairiantGraph::edgeConnectResult(){
         int h2 = (*hpCountMap)[currPos][2].size();
 
         // new block, set this position as block start 
-        if( h1 == 0 && h2 == 0 ){
+        if( h1 == h2 ){
             // No new blocks should be created if the next SNP has already been picked up
             if( currPos < lastConnectPos ){
                 continue;
@@ -269,11 +269,9 @@ void VairiantGraph::edgeConnectResult(){
             (*hpResult)[currPos] = 1;
         }
         else{
-            if( h1 > h2 || h1 < h2 ){
-                int currHP = ( h1 > h2 ? 1 : 2 );
-                (*hpResult)[currPos] = currHP;
-                (*phasedBlocks)[blockStart].push_back(currPos);
-            }
+            int currHP = ( h1 > h2 ? 1 : 2 );
+            (*hpResult)[currPos] = currHP;
+            (*phasedBlocks)[blockStart].push_back(currPos);
         }
         
         // Check if there is no edge from current node


### PR DESCRIPTION
### issue
When h1 == h2 != 0, lastConnectPos gets updated, but no further information is passed along.
### fix
Ensure that this condition enters the newblock process.