### PR TITLE
Pochung

### DIFF
--- a/ModCall.cpp
+++ b/ModCall.cpp
@@ -126,10 +126,6 @@ void ModCallOptions(int argc, char** argv)
             die = true;
         }
     }
-    // else{
-    //     std::cerr << SUBPROGRAM ": missing SNP file.\n";
-    //     die = true;
-    // }
     
 	if( opt::bamFileVec.size() != 0 )
     {

--- a/ModCall.cpp
+++ b/ModCall.cpp
@@ -65,7 +65,7 @@ namespace opt
     static std::vector<std::string> bamFileVec;
     static float modThreshold = 0.8;
     static float unModThreshold = 0.2;
-    static float heterRatio = 0.4;
+    static float heterRatio = 0.6;
     static float noiseRatio = 0.2;
     static int connectAdjacent = 20;
     static float connectConfidence = 0.9;

--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -804,18 +804,17 @@ void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant, std::st
             while (variant2Iter != (*readIter).variantVec.end() && searchCount < 50) {
                 if (!(variant1Iter->type == VariantType::SNP && variant2Iter->type == VariantType::SNP) ) {
 
-                    int pos1 = variant1Iter->position;
-                    int pos2 = variant2Iter->position;
-                    auto edgeIter = edgeList->find(pos1);
+                    int pos = variant1Iter->position;
+                    auto edgeIter = edgeList->find(pos);
                     if (edgeIter == edgeList->end()) {
-                        (*edgeList)[pos1] = new VariantEdge(pos1);
+                        (*edgeList)[pos] = new VariantEdge(pos);
                     }
 
                     if (variant1Iter->allele == 0) {
-                        (*edgeList)[pos1]->ref->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
+                        (*edgeList)[pos]->ref->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
                     } 
                     else if (variant1Iter->allele == 1) {
-                        (*edgeList)[pos1]->alt->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
+                        (*edgeList)[pos]->alt->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
                     }
                 }
                 ++searchCount;
@@ -862,7 +861,6 @@ void MethylationGraph::connectResults(std::string chrName, std::vector<int> &pas
 
             if(isMethylation(currPos)){
                 auto searchNodeIter = nextNodeIter;
-                bool snpAround = false;
                 // Continue searching until we find a SNP or reach the end of nodeInfo
                 while (searchNodeIter != nodeInfo->end() && searchCount < params->connectAdjacent) {
                     std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(searchNodeIter->first);
@@ -871,8 +869,7 @@ void MethylationGraph::connectResults(std::string chrName, std::vector<int> &pas
                     if(totalConnectReads <= minimumConnection){
                         break;
                     }
-                    if(isSNP(searchNodeIter->first)) {   
-                        snpAround = true;      
+                    if(isSNP(searchNodeIter->first)) {     
                         double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
                         hasConnect.push_back(currPos);
                         if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && strongMethylationPoints.count(currPos) == 0) {
@@ -1074,11 +1071,10 @@ void MethylationGraph::connectResults(std::string chrName, std::vector<int> &pas
             }
             std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos);
             int totalConnectReads = tmp.first + tmp.second;
-            double minimumConnection = std::max(((*nodeInfo)[pos].size() + (*nodeInfo)[prevPos].size()) / 4.0, 6.0); 
             double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
             if(totalConnectReads != 0){
                 
-                if (majorRatio >= params->connectConfidence && totalConnectReads >= /*minimumConnection*/6 ) {
+                if (majorRatio >= params->connectConfidence && totalConnectReads >= 6 ) {
                     hasGoodPrevConnection = true;
                 }
             }
@@ -1093,7 +1089,6 @@ void MethylationGraph::connectResults(std::string chrName, std::vector<int> &pas
             }
             std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
             int totalConnectReads = tmp.first + tmp.second;
-            double minimumConnection = std::max(((*nodeInfo)[pos].size() + (*nodeInfo)[nextPos].size()) / 4.0, 6.0); 
             double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
             if(totalConnectReads != 0){
                 if (majorRatio >= params->connectConfidence && totalConnectReads >= 6 ) {

--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -596,7 +596,7 @@ void MethBamParser::exportResult(std::string chrName, std::string chrSquence, in
 
 void writeResultVCF( ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo, std::map<std::string,std::ostringstream> &chrModCallResult){
 
-    std::ofstream modCallResultVcf(params.resultPrefix+".vcf"/*, std::ios_base::app*/);
+    std::ofstream modCallResultVcf(params.resultPrefix+".vcf", std::ios_base::app);
     if(!modCallResultVcf.is_open()){
         std::cerr<<"Fail to open output file :\n";
     }

--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <fstream>
 #include <typeinfo>
+#include <algorithm>
 #include "htslib/thread_pool.h"
 #include "htslib/sam.h"
 
@@ -32,25 +33,33 @@ MethFastaParser::MethFastaParser(std::string fastaFile, std::vector<ReferenceChr
 MethFastaParser::~MethFastaParser(){
 }
 
-MethBamParser::MethBamParser(ModCallParameters &in_params, std::string &in_refString){
+MethBamParser::MethBamParser(std::string inputChrName, ModCallParameters &in_params, MethSnpParser &snpMap, std::string &ref_string):chrName(inputChrName){
     params=&in_params;
-    refString=&in_refString;
-    refstartpos = 0;
-    
+    refString = &ref_string;
+    refstartpos = 0;    
     chrMethMap = new std::map<int , MethPosInfo>;
     readStartEndMap = new std::map<int, std::pair<int,int>>; 
+
+    currentVariants = new std::map<int, RefAlt>;
+
+    if(snpMap.hasValidSnpData()){
+        (*currentVariants) = snpMap.getVariants_markindel(chrName, ref_string);
+    }
+
+    firstVariantIter = currentVariants->begin();
 }
 
 MethBamParser::~MethBamParser(){
     delete chrMethMap;
     delete readStartEndMap;
+    delete currentVariants;
 }
 
-void MethBamParser::detectMeth(std::string chrName, int chr_len, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec){
-
-
+void MethBamParser::detectMeth(std::string chrName, int lastSNPPos, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec){
+    // record SNP start iter
+    std::map<int, RefAlt>::iterator tmpFirstVariantIter = firstVariantIter;
     for( auto bamFile: params->bamFileVec ){
-
+        firstVariantIter = tmpFirstVariantIter;
         // open cram file
         samFile *fp_in = hts_open(bamFile.c_str(),"r");
         // set reference
@@ -66,7 +75,7 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, htsThreadPool &
             exit(1);
         }
         
-        std::string range = chrName + ":1-" + std::to_string(chr_len);
+        std::string range = chrName + ":1-" + std::to_string(lastSNPPos);
         hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
 
         
@@ -87,8 +96,8 @@ void MethBamParser::detectMeth(std::string chrName, int chr_len, htsThreadPool &
                 continue;
             }
             parse_CIGAR(*bamHdr,*aln, readVariantVec);
-
         }
+
         hts_idx_destroy(idx);
         bam_hdr_destroy(bamHdr);
         bam_destroy1(aln);
@@ -102,9 +111,9 @@ void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::
     // hts_base_mod_state can parse MM, ML and MN tags
     hts_base_mod_state *mod_state = hts_base_mod_state_alloc();
     if( bam_parse_basemod( &aln, mod_state) < 0 ){
-        std::cout<<bam_get_qname(&aln)<<"\tFail pase MM\\ML\n";
+        hts_base_mod_state_free(mod_state);
+        return;
     }
-    
     /* 
     // see detail https://github.com/samtools/htslib/issues/1550
     
@@ -133,9 +142,11 @@ void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::
     // forward strand is checked from head to tail
     // reverse strand is checked from tail to head
     int refpos = (bam_is_rev(&aln) ? refstart + 1 : refstart);
+    int ref_pos = aln.core.pos;
     //auto qmethiter = (align.is_reverse ? align.queryMethVec.end()-1 : align.queryMethVec.begin() );
-    //std::cout<<(*tmpReadResult).read_name<<"\t"<<align.queryMethVec.size()<<"\n";
     int querypos = 0;
+    int aln_core_n_cigar = aln.core.n_cigar;
+    uint32_t *cigar = bam_get_cigar(&aln);
     
     hts_base_mod mods[5];
     int pos;
@@ -143,23 +154,118 @@ void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::
     int n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
     if( n <= 0 ){ 
         hts_base_mod_state_free(mod_state);
+        delete tmpReadResult;
         return;
     }
+
+    while( firstVariantIter != currentVariants->end() && (*firstVariantIter).first < ref_pos ){
+        firstVariantIter++;
+    }
+    // set variant start for current alignment
+    std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
     
     //Parse CIGAR 
     for(int cigaridx = 0; cigaridx < int(aln.core.n_cigar) ; cigaridx++){
-      uint32_t *cigar = bam_get_cigar(&aln);
-      int cigar_op = bam_cigar_op(cigar[cigaridx]);
-      int length = bam_cigar_oplen(cigar[cigaridx]);
+
+        int cigar_op = bam_cigar_op(cigar[cigaridx]);
+        int length = bam_cigar_oplen(cigar[cigaridx]);
+        int variantPos = (*currentVariantIter).first;
+        // get the first variant detected by the alignment.
+        /*while( currentVariantIter != currentVariants->end() && variantPos < ref_pos ){
+            currentVariantIter++;
+            variantPos = (*currentVariantIter).first;
+        }*/
+        //while((currentVariantIter != currentVariants->end() && variantPos < ref_pos + length)){
+            if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
+                while(currentVariantIter != currentVariants->end() && currentVariantIter->first < ref_pos + length){
+                    int variantPos = currentVariantIter->first;
+                    if(variantPos >= ref_pos){
+                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
+                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
+                        int offset = variantPos - ref_pos;
+                        int base_q = 0;
+                        int allele = -1;
+
+                        // The position of the variant exceeds the length of the read.
+                        if( querypos + offset + 1 > int(aln.core.l_qseq) ){
+                            return;
+                        }
+
+                        // SNP
+                        if( refAlleleLen == 1 && altAlleleLen == 1){
+                            char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos + offset)];
+                            if(base == (*currentVariantIter).second.Ref[0])
+                                allele = 0;
+                            else if(base == (*currentVariantIter).second.Alt[0])
+                                allele = 1;
+
+                            base_q = bam_get_qual(&aln)[querypos + offset];
+                        } 
+                
+                        // insertion
+                        //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
+                        if( refAlleleLen == 1 && altAlleleLen != 1 && cigaridx+1 < aln_core_n_cigar){
+                    
+                            // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
+                    
+                            // uint8_t *qstring = bam_get_seq(aln); 
+                            // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
+                            // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
+
+                            if ( ref_pos + length - 1 == variantPos && bam_cigar_op(cigar[cigaridx+1]) == 1 ) {
+                                allele = 1 ;
+                            }
+                            else {
+                                allele = 0 ;
+                            }
+                            // using this quality to identify indel
+                            base_q = -4;
+
+                            // using this quality to identify danger indel
+                            if ( (*currentVariantIter).second.is_danger ) {
+                                base_q = -5 ;
+                            }
+                        } 
+                
+                        // deletion
+                        //if( refAlleleLen != 1 && altAlleleLen == 1 && align.op[i+1] == 2 && i+1 < align.cigar_len){
+                        if( refAlleleLen != 1 && altAlleleLen == 1 && cigaridx+1 < aln_core_n_cigar) {
+
+                            if ( ref_pos + length - 1 == variantPos && bam_cigar_op(cigar[cigaridx+1]) == 2 ) {
+                                allele = 1 ;
+                            }
+                            else {
+                                allele = 0 ;
+                            }
+                            // using this quality to identify indel
+                            base_q = -4;
+
+                            // using this quality to identify danger indel
+                            if ( (*currentVariantIter).second.is_danger ) {
+                                base_q = -5 ;
+                            }
+                        } 
+                
+                        if( allele != -1){
+                            // record snp result
+                            (*tmpReadResult).variantVec.emplace_back(variantPos, allele, base_q, VariantType::SNP); 
+                            (*chrMethMap)[variantPos].variantType = VariantType::SNP;                      
+                        }
+                    }
+                    currentVariantIter++;
+                }
+            }
+            //else break;
+        //}
+
+        // CIGAR operators: MIDNSHP=X correspond 012345678
+        // 0: alignment match (can be a sequence match or mismatch)
+        // 7: sequence match
+        // 8: sequence mismatch
       
-      // CIGAR operators: MIDNSHP=X correspond 012345678
-      // 0: alignment match (can be a sequence match or mismatch)
-      // 7: sequence match
-      // 8: sequence mismatch
-      
-      if(cigar_op == 0 || cigar_op == 7 || cigar_op == 8){
-          while(true){
-               if( pos > (querypos+length) ){
+        if(cigar_op == 0 || cigar_op == 7 || cigar_op == 8){
+            while(true){
+                if( pos > (querypos+length) ){
                     break;
                 }
                 if( n <= 0 ){
@@ -169,69 +275,137 @@ void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::
                 if(bam_is_rev(&aln)){
                     methrpos = pos - querypos + refpos - 1;
                     
-                }else{
+                }
+                else{
                     methrpos = pos - querypos + refpos;
                 }
 
                 if( int((*refString).length()) < methrpos ){
                     break;
                 }
+
                 for (int j = 0; j < n && j < 5; j++) {
-                    if (mods[j].modified_base == 109 && pos <= (querypos+length)) {
+                    auto it = chrMethMap->find(methrpos);
+                    if (mods[j].modified_base == 109 && pos <= (querypos+length) && (it == chrMethMap->end() || it->second.variantType == VariantType::MOD)){
                         //modification
-                        if( mods[j].qual >= params->modThreshold*255 ){
+                        if( mods[j].qual >= params->modThreshold*255){
                             (*chrMethMap)[methrpos].methreadcnt++;
+                            (*chrMethMap)[methrpos].variantType = VariantType::MOD;
                             //strand - is 1, strand + is 0
                             (*chrMethMap)[methrpos].strand = (bam_is_rev(&aln) ? 1 : 0);
-                            (*chrMethMap)[methrpos].modReadVec.push_back(bam_get_qname(&aln));
-                            (*tmpReadResult).variantVec.emplace_back(methrpos, 0, 60);
-
+                            (*chrMethMap)[methrpos].modReadVec.emplace_back(bam_get_qname(&aln));
+                            (*tmpReadResult).variantVec.emplace_back(methrpos, 0, 60, VariantType::MOD);
                         }
                         //non-modification (not include no detected)
                         else if( mods[j].qual <= params->unModThreshold*255 ){ 
                             (*chrMethMap)[methrpos].canonreadcnt++;
-                            (*chrMethMap)[methrpos].nonModReadVec.push_back(bam_get_qname(&aln));
-                            (*tmpReadResult).variantVec.emplace_back(methrpos, 1, 60  );
+                            (*chrMethMap)[methrpos].nonModReadVec.emplace_back(bam_get_qname(&aln));
+                            (*tmpReadResult).variantVec.emplace_back(methrpos, 1, 60, VariantType::MOD);
                         }
                         else{
                             (*chrMethMap)[methrpos].noisereadcnt++;
                         }
-                      }
-                  }
-                  n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-             }
-          querypos += length;
-          refpos += length;
-      }
-      // 1: insertion to the reference
-      else if(cigar_op == 1){ 
-          while(n>0 && pos <= (querypos+length)){
-            n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-          }
-          querypos += length;
-          
-      }
-      // 2: deletion from the reference
-      else if(cigar_op == 2){
-          refpos += length;
-      }
-      // 3: skipped region from the reference
-      else if(cigar_op == 3){
-          refpos += length;
-      }
-      // 4: soft clipping (clipped sequences present in SEQ)
-      else if(cigar_op == 4){
-          while(n>0 && pos <= (querypos+length)){
-            n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-          }
-          querypos += length;
-      }
-      // 5: hard clipping (clipped sequences NOT present in SEQ)
-      // 6: padding (silent deletion from padded reference)
-      else if(cigar_op == 5 || cigar_op == 6){
-          //do nothing
-          refpos += length;
-      }
+                    }
+                }
+                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+            }
+            querypos += length;
+            refpos += length;
+            ref_pos += length;
+        }
+        // 1: insertion to the reference
+        else if(cigar_op == 1){ 
+            while(n>0 && pos <= (querypos+length)){
+                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+            }
+            querypos += length;   
+        }
+        // 2: deletion from the reference
+        else if(cigar_op == 2){
+            if(*refString != ""){
+                int del_len = length;
+                if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
+                    //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
+                        // special case
+                    //}
+                }
+                else if( (*currentVariantIter).first >= ref_pos  && (*currentVariantIter).first < ref_pos + del_len ){
+                    // check snp in homopolymer
+                    if( homopolymerLength((*currentVariantIter).first , *refString) >=3 ){
+                        
+                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
+                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
+                        int base_q = 0;  
+                        
+                        if( querypos + 1 > aln.core.l_qseq ){
+                            hts_base_mod_state_free(mod_state);
+                            delete tmpReadResult;
+                            return;
+                        }
+
+                        int allele = -1;
+                        // SNP
+                        if( refAlleleLen == 1 && altAlleleLen == 1){
+                            // get the next match
+                            char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos)];
+                            if( base == (*currentVariantIter).second.Ref[0] ){
+                                allele = 0;
+                            }
+                            else if( base == (*currentVariantIter).second.Alt[0] ){
+                                allele = 1;
+                            }
+                            base_q = bam_get_qual(&aln)[querypos];
+                        }
+                        // the read deletion contain VCF's deletion
+                        else if( refAlleleLen != 1 && altAlleleLen == 1 ){
+
+                            if( refAlleleLen != 1 && altAlleleLen == 1){
+                                //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
+                                //std::string refSeq = (*currentVariantIter).second.Ref;
+                                //std::string altSeq = (*currentVariantIter).second.Alt;
+
+                                allele = 1;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            else if ( allele == -1 ) {
+                                allele = 0;
+                                // using this quality to identify indel
+                                base_q = -4;
+                            }
+                            
+                        }
+                        
+                        if(allele != -1){
+                            (*tmpReadResult).variantVec.emplace_back((*currentVariantIter).first, allele, base_q, VariantType::SNP);
+                            (*chrMethMap)[variantPos].variantType = VariantType::SNP;
+                            currentVariantIter++;
+                        }
+
+                    }
+                }
+            }
+            refpos += length;
+            ref_pos += length;
+        }
+        // 3: skipped region from the reference
+        else if(cigar_op == 3){
+            refpos += length;
+            ref_pos += length;
+        }
+        // 4: soft clipping (clipped sequences present in SEQ)
+        else if(cigar_op == 4){
+            while(n>0 && pos <= (querypos+length)){
+                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+            }
+            querypos += length;
+        }
+        // 5: hard clipping (clipped sequences NOT present in SEQ)
+        // 6: padding (silent deletion from padded reference)
+        else if(cigar_op == 5 || cigar_op == 6){
+            //do nothing
+            refpos += length;
+        }
     }
     
     hts_base_mod_state_free(mod_state);
@@ -247,113 +421,182 @@ void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::
         (*readStartEndMap)[refend].first -= 1;
     }
     
-    if( (*tmpReadResult).variantVec.size() > 0 )
-        readVariantVec.push_back((*tmpReadResult));
-
+    if( (*tmpReadResult).variantVec.size() > 0 ){
+        (*tmpReadResult).sort();
+        readVariantVec.emplace_back((*tmpReadResult));
+    }
     delete tmpReadResult;
 }
 
-void MethBamParser::exportResult(std::string chrName, std::string chrSquence, int chrLen , std::map<int,std::vector<int>> &passPosition, std::ostringstream &modCallResult){
-    
-    for(std::map<int , MethPosInfo>::iterator posinfoIter = chrMethMap->begin(); posinfoIter != chrMethMap->end(); posinfoIter++){
-        std::string infostr= "";
-        std::string eachpos;
-        std::string samplestr;
-        std::string strandinfo;
-        std::string ref;
-        bool print = false;
-        
-        auto passPosIter =  passPosition.find((*posinfoIter).first);
-        auto prepassPosIter =  passPosition.find((*posinfoIter).first - 1);
-        auto nextpassPosIter =  passPosition.find((*posinfoIter).first + 1);
-        
-        // Determine continuous methylation position (CpG) that can be output
-        if(!passPosition[passPosIter->first].empty() && !passPosition[prepassPosIter->first].empty()){
-            for(std::vector<int>::iterator posIter = passPosition[passPosIter->first].begin(); posIter != passPosition[passPosIter->first].end(); posIter++){
-                for(std::vector<int>::iterator posIter2 = passPosition[prepassPosIter->first].begin(); posIter2 != passPosition[prepassPosIter->first].end(); posIter2++){
-                    if((*posIter)-1 == (*posIter2)){
-                        print = true;
-                    }
-                }
-            }
-        }
-        if(!passPosition[passPosIter->first].empty() && !passPosition[nextpassPosIter->first].empty()){
-            for(std::vector<int>::iterator posIter = passPosition[passPosIter->first].begin(); posIter != passPosition[passPosIter->first].end(); posIter++){
-                for(std::vector<int>::iterator posIter2 = passPosition[nextpassPosIter->first].begin(); posIter2 != passPosition[nextpassPosIter->first].end(); posIter2++){
-                    if((*posIter)+1 == (*posIter2)){
-                        print = true;
-                    }
-                }
-            }
-        }
+void MethBamParser::exportResult(std::string chrName, std::string chrSquence, int chrLen, std::vector<int> &passPosition, std::ostringstream &modCallResult){
 
-        // prevent variant coordinates from exceeding the reference.
-        if( chrLen < (*posinfoIter).first ){
-            continue;
-        }
-
-        // prevent abnormal REF allele.
-        ref = chrSquence.substr((*posinfoIter).first,1);
-        if( ref != "A" && ref != "T" && ref != "C" && ref != "G" && 
-            ref != "a" && ref != "t" && ref != "c" && ref != "g"  ){
-            continue;
-        }
-        
-        // set variant strand
-        if( (*posinfoIter).second.strand == 1 ){
-            strandinfo = "RS=N;";
-        }
-        else if( (*posinfoIter).second.strand == 0 ){
-            strandinfo = "RS=P;";
-        }
-        else{
-            continue;
-        }
-        
-        //Output contains only consecutive methylation position (CpG)
-        if( (prepassPosIter == passPosition.end() && nextpassPosIter == passPosition.end()) || passPosIter ==  passPosition.end() || print == false){
-            if( params->outputAllMod ){
-                int nonmethcnt = (*posinfoIter).second.canonreadcnt;
-                samplestr = (*posinfoIter).second.heterstatus + ":" + std::to_string((*posinfoIter).second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string((*posinfoIter).second.depth);
-
-                eachpos = chrName + "\t" + std::to_string((*posinfoIter).first + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "." + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
-                modCallResult<<eachpos;
-            }         
-            continue;
-        }
-        
-        // append modification reads
-        if((*posinfoIter).second.modReadVec.size() > 0 ){
-            infostr += "MR=";
-            for(auto readName : (*posinfoIter).second.modReadVec ){
-                infostr += readName + ",";
-            }
-            infostr.back() = ';';
-        }
+    if(params->outputAllMod){
+        for(const auto& [currPos, info] : *chrMethMap){
+            auto posinfoIter = chrMethMap->find(currPos);
+            if (posinfoIter == chrMethMap->end()) return;
+            std::string infostr = "";
+            std::string eachpos;
+            std::string samplestr;
+            std::string strandinfo;
+            std::string ref;
             
-        // append non modification reads
-        if((*posinfoIter).second.nonModReadVec.size() > 0 ){
-            infostr += "NR=";
-            for(auto readName : (*posinfoIter).second.nonModReadVec ){
-                infostr += readName + ",";
-            }
-            infostr.back() = ';';
-        }
+            // 防止变异坐标超出参考序列范围
+            if (chrLen < currPos) return;
 
-        if((*posinfoIter).second.heterstatus == "0/1"){
-            int nonmethcnt = (*posinfoIter).second.canonreadcnt;
-            samplestr = (*posinfoIter).second.heterstatus + ":" + std::to_string((*posinfoIter).second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string((*posinfoIter).second.depth);
+            // 防止异常的 REF 等位基因
+            ref = chrSquence.substr(currPos, 1);
+            if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
+                ref != "a" && ref != "t" && ref != "c" && ref != "g") return;
+
+            if (info.strand == 1) strandinfo = "RS=N;";
+            else if (info.strand == 0) strandinfo = "RS=P;";
+            else return;
+
+            // append modification reads
+            if((*posinfoIter).second.modReadVec.size() > 0 ){
+                infostr += "MR=";
+                for(auto readName : (*posinfoIter).second.modReadVec ){
+                    infostr += readName + ",";
+                }
+                infostr.back() = ';';
+            }
+                
+            // append non modification reads
+            if((*posinfoIter).second.nonModReadVec.size() > 0 ){
+                infostr += "NR=";
+                for(auto readName : (*posinfoIter).second.nonModReadVec ){
+                    infostr += readName + ",";
+                }
+                infostr.back() = ';';
+            }
+            samplestr = (*posinfoIter).second.heterstatus + ":" + std::to_string((*posinfoIter).second.methreadcnt) + ":" + std::to_string((*posinfoIter).second.canonreadcnt) + ":" + std::to_string((*posinfoIter).second.depth);
 
             eachpos = chrName + "\t" + std::to_string((*posinfoIter).first + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
 
             modCallResult<<eachpos;
         }
     }
+    else{
+        // 用於跟踪已處理過的位置，避免重複輸出
+        std::set<int> processedPositions;
+        
+        // passPosition 已經有序，不需要額外排序
+        for(const auto& pos : passPosition){
+            // 如果位置已經處理過，跳過
+            if(processedPositions.count(pos) > 0) {
+                continue;
+            }
+            
+            // 處理位置 pos
+            auto posinfoIter = chrMethMap->find(pos);
+            if (posinfoIter != chrMethMap->end()) {
+                std::string infostr = "";
+                std::string eachpos;
+                std::string samplestr;
+                std::string strandinfo;
+                std::string ref;
+                
+                // 防止變異座標超出參考序列範圍
+                if (chrLen < pos) continue;
+
+                // 防止異常的 REF 等位基因
+                ref = chrSquence.substr(pos, 1);
+                if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
+                    ref != "a" && ref != "t" && ref != "c" && ref != "g") continue;
+
+                if (posinfoIter->second.strand == 1) strandinfo = "RS=N;";
+                else if (posinfoIter->second.strand == 0) strandinfo = "RS=P;";
+                else continue;
+
+                // 添加修飾讀取
+                if(posinfoIter->second.modReadVec.size() > 0) {
+                    infostr += "MR=";
+                    for(auto& readName : posinfoIter->second.modReadVec) {
+                        infostr += readName + ",";
+                    }
+                    infostr.back() = ';';
+                }
+                
+                // 添加非修飾讀取
+                if(posinfoIter->second.nonModReadVec.size() > 0) {
+                    infostr += "NR=";
+                    for(auto& readName : posinfoIter->second.nonModReadVec) {
+                        infostr += readName + ",";
+                    }
+                    infostr.back() = ';';
+                }
+                
+                // 輸出所有修飾位置或只輸出異質性位置
+                if(params->outputAllMod || posinfoIter->second.heterstatus == "0/1") {
+                    int nonmethcnt = posinfoIter->second.canonreadcnt;
+                    samplestr = posinfoIter->second.heterstatus + ":" + std::to_string(posinfoIter->second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string(posinfoIter->second.depth);
+                    
+                    eachpos = chrName + "\t" + std::to_string(pos + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
+                    
+                    modCallResult << eachpos;
+                }
+            }
+            processedPositions.insert(pos);
+            
+            // 處理位置 pos+1
+            int nextPos = pos + 1;
+            auto nextPosinfoIter = chrMethMap->find(nextPos);
+            if (nextPosinfoIter != chrMethMap->end() && processedPositions.count(nextPos) == 0) {
+                std::string infostr = "";
+                std::string eachpos;
+                std::string samplestr;
+                std::string strandinfo;
+                std::string ref;
+                
+                // 防止變異座標超出參考序列範圍
+                if (chrLen < nextPos) continue;
+
+                // 防止異常的 REF 等位基因
+                ref = chrSquence.substr(nextPos, 1);
+                if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
+                    ref != "a" && ref != "t" && ref != "c" && ref != "g") continue;
+
+                if (nextPosinfoIter->second.strand == 1) strandinfo = "RS=N;";
+                else if (nextPosinfoIter->second.strand == 0) strandinfo = "RS=P;";
+                else continue;
+
+                // 添加修飾讀取
+                if(nextPosinfoIter->second.modReadVec.size() > 0) {
+                    infostr += "MR=";
+                    for(auto& readName : nextPosinfoIter->second.modReadVec) {
+                        infostr += readName + ",";
+                    }
+                    infostr.back() = ';';
+                }
+                
+                // 添加非修飾讀取
+                if(nextPosinfoIter->second.nonModReadVec.size() > 0) {
+                    infostr += "NR=";
+                    for(auto& readName : nextPosinfoIter->second.nonModReadVec) {
+                        infostr += readName + ",";
+                    }
+                    infostr.back() = ';';
+                }
+                
+                // 輸出所有修飾位置或只輸出異質性位置
+                if(params->outputAllMod || nextPosinfoIter->second.heterstatus == "0/1") {
+                    int nonmethcnt = nextPosinfoIter->second.canonreadcnt;
+                    samplestr = nextPosinfoIter->second.heterstatus + ":" + std::to_string(nextPosinfoIter->second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string(nextPosinfoIter->second.depth);
+                    
+                    eachpos = chrName + "\t" + std::to_string(nextPos + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
+                    
+                    modCallResult << eachpos;
+                }
+                processedPositions.insert(nextPos);
+            }
+        }
+    }
+    
 }
 
 void writeResultVCF( ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo, std::map<std::string,std::ostringstream> &chrModCallResult){
 
-    std::ofstream modCallResultVcf(params.resultPrefix+".vcf", std::ios_base::app);
+    std::ofstream modCallResultVcf(params.resultPrefix+".vcf"/*, std::ios_base::app*/);
     if(!modCallResultVcf.is_open()){
         std::cerr<<"Fail to open output file :\n";
     }
@@ -381,10 +624,11 @@ void writeResultVCF( ModCallParameters &params, std::vector<ReferenceChromosome>
     }
 }
 
-void MethBamParser::judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &fReadVariantVec, std::vector<ReadVariant> &rReadVariantVec){
-    
+void MethBamParser::judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &modReadVariantVec){
+    //Find all methylation sites and determine their genotypes
     for(std::map<int, MethPosInfo>::iterator chrmethmapIter = chrMethMap->begin(); chrmethmapIter != chrMethMap->end(); chrmethmapIter++){
-        // methylation and noise are the feature to identify ASM candidate
+
+        // Determine methylation genotype
         float methcnt      = (*chrmethmapIter).second.methreadcnt;
         float nonmethcnt   = (*chrmethmapIter).second.canonreadcnt;
         float depth        = (*chrmethmapIter).second.depth;
@@ -396,11 +640,12 @@ void MethBamParser::judgeMethGenotype(std::string chrName, std::vector<ReadVaria
         if(std::max(methcnt, nonmethcnt) == 0){
             continue;
         }
-
+        
         float heterRatio = std::min(methcnt, nonmethcnt) / std::max(methcnt, nonmethcnt);
         float noiseRatio = noisereadcnt / depth;
         
-        if(heterRatio >= params->heterRatio && noiseRatio <= params->noiseRatio ){
+        // Determine methylation genotype for each position individually
+        if(heterRatio >= params->heterRatio && noiseRatio <= params->noiseRatio){
             (*chrmethmapIter).second.heterstatus = "0/1";
         }
         else if(methcnt >= nonmethcnt){
@@ -409,43 +654,84 @@ void MethBamParser::judgeMethGenotype(std::string chrName, std::vector<ReadVaria
         else{
             (*chrmethmapIter).second.heterstatus = "0/0";
         }
-
-    }
-
-    for(std::vector<ReadVariant>::iterator rIter = readVariantVec.begin() ; rIter != readVariantVec.end() ; rIter++ ){
-
-        ReadVariant fVec;
-        ReadVariant rVec;
-        
-        for(std::vector<Variant>::iterator vIter = (*rIter).variantVec.begin(); vIter != (*rIter).variantVec.end() ; vIter++){
-            if( (*chrMethMap)[(*vIter).position].heterstatus == "0/1" ){
-                if((*rIter).is_reverse){
-                    rVec.variantVec.push_back((*vIter));
-                }
-                else{
-                    fVec.variantVec.push_back((*vIter));
-                }
-            }
-        }
-        
-        if( fVec.variantVec.size() > 0 ){
-            fVec.read_name = (*rIter).read_name;
-            fVec.is_reverse = false;
-            fReadVariantVec.push_back(fVec);
-            
-            fVec.variantVec.clear();
-            fVec.variantVec.shrink_to_fit();
-        }
-        if( rVec.variantVec.size() > 0 ){
-            rVec.read_name = (*rIter).read_name;
-            rVec.is_reverse = true;
-            rReadVariantVec.push_back(rVec);
-            
-            rVec.variantVec.clear();
-            rVec.variantVec.shrink_to_fit();
-        }
     }
     
+    std::set<int> positionPairs; 
+
+    // Only process cases with forward-reverse strand pairs
+    for(auto iter = chrMethMap->begin(); iter != chrMethMap->end(); iter++){        
+        if(iter->second.strand == 0 && iter->second.variantType == VariantType::MOD){
+            int currPos = iter->first;
+            int nextPos = currPos + 1; 
+            
+            auto nextIter = chrMethMap->find(nextPos);
+            // Check that the next position exists, is on the reverse strand, and is a methylation site
+            if(nextIter != chrMethMap->end() && nextIter->second.strand == 1 && nextIter->second.variantType == VariantType::MOD){
+                // Calculate methylation statistics after combining
+                float totalMethCnt = iter->second.methreadcnt + nextIter->second.methreadcnt;
+                float totalNonMethCnt = iter->second.canonreadcnt + nextIter->second.canonreadcnt;
+                float totalDepth = iter->second.depth + nextIter->second.depth;
+                float totalNoiseCnt = totalDepth - totalMethCnt - totalNonMethCnt;
+                
+                if(std::max(totalMethCnt, totalNonMethCnt) == 0){
+                    continue;
+                }
+                
+                float combinedHeterRatio = std::min(totalMethCnt, totalNonMethCnt) / std::max(totalMethCnt, totalNonMethCnt);
+                float combinedNoiseRatio = totalNoiseCnt / totalDepth;
+                
+                // Determine methylation genotype based on combined data
+                std::string combinedStatus;
+                if(combinedHeterRatio >= params->heterRatio && combinedNoiseRatio <= params->noiseRatio){
+                    combinedStatus = "0/1";
+                    positionPairs.insert(currPos);
+                }
+                else if(totalMethCnt >= totalNonMethCnt){
+                    combinedStatus = "1/1";
+                }
+                else{
+                    combinedStatus = "0/0";
+                }                
+                // Update the status of forward and reverse strand positions
+                iter->second.heterstatus = combinedStatus;
+                nextIter->second.heterstatus = combinedStatus;
+            }
+        }
+    }
+
+    // Handle all variants uniformly to avoid duplication
+    for(auto& read : readVariantVec){
+        ReadVariant newRead;
+        newRead.read_name = read.read_name;
+        newRead.is_reverse = read.is_reverse;
+        
+        for(auto& variant : read.variantVec){
+            int pos = variant.position;
+            // Check if the variant is methylation-related and marked as heterogeneous in chrMethMap
+            if(variant.type == VariantType::MOD) {
+                if(chrMethMap->find(pos)->second.strand == 0){
+                    auto pairIter = positionPairs.find(pos);
+                    if(pairIter != positionPairs.end()){
+                        newRead.variantVec.emplace_back(pos, variant.allele, variant.quality, VariantType::MOD);
+                    }
+                }
+                else if(chrMethMap->find(pos)->second.strand == 1){
+                    auto pairIter = positionPairs.find(pos-1);
+                    if(pairIter != positionPairs.end()){
+                        newRead.variantVec.emplace_back(pos-1, variant.allele, variant.quality, VariantType::MOD);
+                    }
+                }
+            } 
+            else if(variant.type == VariantType::SNP) {
+                newRead.variantVec.emplace_back(variant);
+            }
+        }
+        if(!newRead.variantVec.empty()){
+            modReadVariantVec.push_back(newRead);
+        }
+        newRead.variantVec.clear();
+        newRead.variantVec.shrink_to_fit();
+    }
 }
 
 void MethBamParser::calculateDepth(){
@@ -484,8 +770,7 @@ void MethBamParser::calculateDepth(){
 
 MethylationGraph::MethylationGraph(ModCallParameters &in_params){
     params=&in_params;
-    
-    nodeInfo = new std::map<int,ReadBaseMap*>;
+    nodeInfo = new std::map<int, std::map<std::string, VariantType>>;
     edgeList = new std::map<int,VariantEdge*>;
     forwardModNode = new std::map<int,ReadBaseMap*>;
     reverseModNode = new std::map<int,ReadBaseMap*>;
@@ -494,118 +779,362 @@ MethylationGraph::MethylationGraph(ModCallParameters &in_params){
 MethylationGraph::~MethylationGraph(){
 }
 
-void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant){
+void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant, std::string chrName){
     readVariant = &in_readVariant;
+    int readCount = 0;
+    int vectorSize = 0;
     // iter all read
     for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
         ReadVariant tmpRead;
+        vectorSize += (*readIter).variantVec.size();
+        readCount++;
         
-        for( auto variant : (*readIter).variantVec ){
-            // modification in the forward strand
-            if( variant.quality == -2 ){
-                auto nodeIter = forwardModNode->find(variant.position);
-                if( nodeIter == forwardModNode->end() ){
-                    (*forwardModNode)[variant.position] = new ReadBaseMap();
-                }
-                
-                (*(*forwardModNode)[variant.position])[(*readIter).read_name] = 60;
-
-                continue;
-            }
-            // modification in the reverse strand
-            if( variant.quality == -3 ){
-                auto nodeIter = reverseModNode->find(variant.position);
-                if( nodeIter == reverseModNode->end() ){
-                    (*reverseModNode)[variant.position] = new ReadBaseMap();
-                }
-                
-                (*(*reverseModNode)[variant.position])[(*readIter).read_name] = 60;
-                
-                continue;
-            }
-            
-            
-            tmpRead.variantVec.push_back(variant);
-            
+        for( auto variant : (*readIter).variantVec ){           
             auto nodeIter = nodeInfo->find(variant.position);
             
             if( nodeIter == nodeInfo->end() ){
-                (*nodeInfo)[variant.position] = new ReadBaseMap();
+                (*nodeInfo)[variant.position] = std::map<std::string, VariantType>();
             }
-            
-            (*(*nodeInfo)[variant.position])[(*readIter).read_name] = variant.quality;
+            (*nodeInfo)[variant.position][(*readIter).read_name] = variant.type;
         }
-        // iter all pair of snp and construct initial graph
-        std::vector<Variant>::iterator variant1Iter = tmpRead.variantVec.begin();
-        std::vector<Variant>::iterator variant2Iter = std::next(variant1Iter,1);
-        while(variant1Iter != tmpRead.variantVec.end() && variant2Iter != tmpRead.variantVec.end() ){
 
-            // create new edge if not exist
-            std::map<int,VariantEdge*>::iterator posIter = edgeList->find((*variant1Iter).position);
-            if( posIter == edgeList->end() )
-                (*edgeList)[(*variant1Iter).position] = new VariantEdge((*variant1Iter).position);
+        for (auto variant1Iter = (*readIter).variantVec.begin(); variant1Iter != (*readIter).variantVec.end(); ++variant1Iter) {
+            auto variant2Iter = std::next(variant1Iter);
+            int searchCount = 0;
+            while (variant2Iter != (*readIter).variantVec.end() && searchCount < 50) {
+                if (!(variant1Iter->type == VariantType::SNP && variant2Iter->type == VariantType::SNP) ) {
 
-            // add edge process
-            for(int nextNode = 0 ; nextNode < params->connectAdjacent; nextNode++){
+                    int pos1 = variant1Iter->position;
+                    int pos2 = variant2Iter->position;
+                    auto edgeIter = edgeList->find(pos1);
+                    if (edgeIter == edgeList->end()) {
+                        (*edgeList)[pos1] = new VariantEdge(pos1);
+                    }
 
-                // this allele support ref
-                if( (*variant1Iter).allele == 0 )
-                    (*edgeList)[(*variant1Iter).position]->ref->addSubEdge((*variant1Iter).quality, (*variant2Iter), (*readIter).read_name, 0, 1);
-                // this allele support alt
-                if( (*variant1Iter).allele == 1 )
-                    (*edgeList)[(*variant1Iter).position]->alt->addSubEdge((*variant1Iter).quality, (*variant2Iter), (*readIter).read_name, 0, 1);
-                
-                // next snp
-                variant2Iter++;
-                if( variant2Iter == tmpRead.variantVec.end() ){
-                    break;
+                    if (variant1Iter->allele == 0) {
+                        (*edgeList)[pos1]->ref->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
+                    } 
+                    else if (variant1Iter->allele == 1) {
+                        (*edgeList)[pos1]->alt->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
+                    }
                 }
+                ++searchCount;
+                ++variant2Iter;
             }
-
-            variant1Iter++;
-            variant2Iter = std::next(variant1Iter,1);
         }
     }
 }
 
-void MethylationGraph::connectResults(std::string chrName, std::map<int,std::vector<int>> &passPosition){
+void MethylationGraph::connectResults(std::string chrName, std::vector<int> &passPosition, bool hasValidSnpData){
+    std::set<int> strongMethylationPoints;
+    std::set<int> weakMethylationPoints;
+    std::set<int> weakMethylationPoints2;
+    std::set<int> weakMethylationPoints3;
+    std::set<int> addedPositions;
+    std::set<int> addedPositions2;
+    std::set<int> addedPositions3;
+    std::vector<int> prepassPosition;
+    std::vector<int> hasConnect;
+    int noSnpAround = 0;
 
-    // check clear connect variant
-    for(std::map<int,ReadBaseMap*>::iterator nodeIter = nodeInfo->begin() ; nodeIter != nodeInfo->end() ; nodeIter++ ){
-
-        // check next position
-        std::map<int,ReadBaseMap*>::iterator nextNodeIter = std::next(nodeIter, 1);
-        if( nextNodeIter == nodeInfo->end() ){
-             break;
-        }
-
-        int currPos = nodeIter->first;
-
-        // Check if there is no edge from current node
-        std::map<int,VariantEdge*>::iterator edgeIter = edgeList->find( currPos );
-        if( edgeIter==edgeList->end() )
-            continue;
-
-        // check connect between surrent SNP and next n SNPs
-        for(int i = 0 ; i < params->connectAdjacent ; i++ ){
-            int nextPos = nextNodeIter->first;
-            // get number of RR read and RA read
-            std::pair<int,int> tmp = edgeIter->second->findNumberOfRead(nextPos);
-            int totalConnectReads = tmp.first + tmp.second;
-            int minimumConnection = (((*(*nodeIter).second).size() + (*(*nextNodeIter).second).size())/4);
-
-            double majorRatio = (double)std::max(tmp.first,tmp.second)/(double)(tmp.first+tmp.second);
-            
-
-            if( majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && tmp.first + tmp.second > 6 ){
-                passPosition[currPos].push_back(nextPos);
-                passPosition[nextPos].push_back(currPos);
+    // If no valid SNP data, skip the first pass and directly add all methylation sites to strongMethylationPoints
+    if (!hasValidSnpData) {
+        for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end(); ++nodeIter) {
+            int currPos = nodeIter->first;
+            if(isMethylation(currPos)){
+                strongMethylationPoints.insert(currPos);
             }
-            nextNodeIter++;
-            if( nextNodeIter == nodeInfo->end() )
-                break;
         }
     }
+    else {
+        // First pass: Identify methylation points with strong SNP connections
+        for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end(); ++nodeIter) {
+            int currPos = nodeIter->first;
+            auto nextNodeIter = std::next(nodeIter, 1);
+            int searchCount = 0;
+            if( nextNodeIter == nodeInfo->end() ){
+                break;
+            }
+
+            auto edgeIter = edgeList->find(currPos);
+            if (edgeIter == edgeList->end()) 
+                continue;
+
+            if(isMethylation(currPos)){
+                auto searchNodeIter = nextNodeIter;
+                bool snpAround = false;
+                // Continue searching until we find a SNP or reach the end of nodeInfo
+                while (searchNodeIter != nodeInfo->end() && searchCount < params->connectAdjacent) {
+                    std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(searchNodeIter->first);
+                    int totalConnectReads = tmp.first + tmp.second;
+                    float minimumConnection = std::max(((*nodeIter).second.size() + (*searchNodeIter).second.size())/ 4.0, 6.0);
+                    if(totalConnectReads <= minimumConnection){
+                        break;
+                    }
+                    if(isSNP(searchNodeIter->first)) {   
+                        snpAround = true;      
+                        double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+                        hasConnect.push_back(currPos);
+                        if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && strongMethylationPoints.count(currPos) == 0) {
+                            strongMethylationPoints.insert(currPos);
+                            break;
+                        }
+                    }
+                    ++searchNodeIter;
+                    ++searchCount;
+                }
+                if(std::find(hasConnect.begin(), hasConnect.end(), currPos) == hasConnect.end()){
+                    weakMethylationPoints.insert(currPos);
+                    ++noSnpAround;
+                }
+            }
+            else if(isSNP(currPos)){
+                auto searchNodeIter = nextNodeIter;
+                prepassPosition.push_back(currPos);
+                while(searchNodeIter != nodeInfo->end()) {
+                    std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(searchNodeIter->first);
+                    int totalConnectReads = tmp.first + tmp.second;
+                    float minimumConnection = std::max(((*nodeIter).second.size() + (*searchNodeIter).second.size())/ 4.0, 6.0);
+                    if(totalConnectReads <= minimumConnection){
+                        break;
+                    }
+                    if (isMethylation(searchNodeIter->first)) {
+                        double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+                        hasConnect.push_back(searchNodeIter->first);
+                        if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && strongMethylationPoints.count(nextNodeIter->first) == 0) {
+                            strongMethylationPoints.insert(nextNodeIter->first);
+                        } 
+                    }
+                    ++searchNodeIter;      
+                    ++searchCount;
+                }
+            }
+        }
+    } 
+
+    // Second pass: Evaluate connections between strong methylation points
+    for(auto it1 = strongMethylationPoints.begin(); it1 != strongMethylationPoints.end(); ++it1){
+        int pos1 = *it1;
+        auto it2 = std::next(it1, 1);
+        auto searchNodeIter = it2;
+        int searchCount = 0;
+        auto edgeIter = edgeList->find(pos1);
+        if (edgeIter == edgeList->end()) 
+            continue;
+
+        while(searchNodeIter != strongMethylationPoints.end() && searchCount < params->connectAdjacent) {
+            int pos2 = *searchNodeIter;
+            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos2);
+            int totalConnectReads = tmp.first + tmp.second;
+            float minimumConnection = std::max(((*nodeInfo)[pos1].size() + (*nodeInfo)[pos2].size())/ 4.0, 6.0);
+            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+
+            if(totalConnectReads <= minimumConnection){
+                break;
+            }
+
+            if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection) {
+                // Add positions to passPosition to ensure order and no duplicates
+                if(addedPositions.count(pos1) == 0) {
+                    prepassPosition.push_back(pos1);
+                    addedPositions.insert(pos1);
+                    // Only add positions to weakMethylationPoints if there is valid SNP data (for third pass)
+                    if(hasValidSnpData) {
+                        weakMethylationPoints.insert(pos1);
+                    }
+                }
+                if(addedPositions.count(pos2) == 0) {
+                    prepassPosition.push_back(pos2);
+                    addedPositions.insert(pos2);
+                    // Only add positions to weakMethylationPoints if there is valid SNP data (for third pass)
+                    if(hasValidSnpData) {
+                        weakMethylationPoints.insert(pos2);
+                    }
+                }
+            }
+            ++searchNodeIter;
+            ++searchCount;
+        }
+    }
+    strongMethylationPoints.clear();
+
+    //third pass: evaluate connections between weak methylation points
+    if (hasValidSnpData) {
+        for(auto it1 = weakMethylationPoints.begin(); it1 != weakMethylationPoints.end(); ++it1){
+            int pos1 = *it1;
+
+            auto nextIter = it1;
+            int nextSearchCount = 0;
+            bool isAdded = false;
+            auto edgeIter = edgeList->find(pos1);
+            if (edgeIter == edgeList->end()) 
+                continue;
+            while(++nextIter != weakMethylationPoints.end() && nextSearchCount < params->connectAdjacent) {
+                int nextPos = *nextIter;
+                if(addedPositions.count(nextPos) == 0 && addedPositions.count(pos1) == 0){
+                    ++nextSearchCount;
+                    continue;
+                }
+                isAdded = true;
+                std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
+                int totalConnectReads = tmp.first + tmp.second;
+                float minimumConnection = std::max(((*nodeInfo)[pos1].size() + (*nodeInfo)[nextPos].size())/ 4.0, 6.0);
+                double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+                if(totalConnectReads <= minimumConnection){
+                    break;
+                }
+                if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection ) {
+                    if(std::find(prepassPosition.begin(), prepassPosition.end(), pos1) == prepassPosition.end()){
+                        prepassPosition.push_back(pos1);
+                        weakMethylationPoints2.insert(pos1);
+                        addedPositions2.insert(pos1);
+                    }
+                    if(std::find(prepassPosition.begin(), prepassPosition.end(), nextPos) == prepassPosition.end()){
+                        prepassPosition.push_back(nextPos);
+                        weakMethylationPoints2.insert(nextPos);
+                        addedPositions2.insert(nextPos);
+                    }
+                }
+                ++nextSearchCount;
+            }
+            if(!isAdded){
+                weakMethylationPoints2.insert(pos1);
+            }
+        }
+
+        weakMethylationPoints.clear();
+        addedPositions.clear();
+    }
+    
+    //fourth pass: evaluate connections between weak methylation points2
+    if (hasValidSnpData) {
+        for(auto it1 = weakMethylationPoints2.begin(); it1 != weakMethylationPoints2.end(); ++it1){
+            int pos1 = *it1;
+            auto nextIter = it1;
+            int nextSearchCount = 0;
+            bool isAdded = false;
+            auto edgeIter = edgeList->find(pos1);
+            if (edgeIter == edgeList->end()) 
+                continue;
+            while(++nextIter != weakMethylationPoints2.end() && nextSearchCount < params->connectAdjacent) {
+                int nextPos = *nextIter;
+                if(addedPositions2.count(nextPos) == 0 && addedPositions2.count(pos1) == 0){
+                    ++nextSearchCount;
+                    continue;
+                }
+                isAdded = true;
+                std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
+                int totalConnectReads = tmp.first + tmp.second;
+                float minimumConnection = std::max(((*nodeInfo)[pos1].size() + (*nodeInfo)[nextPos].size())/ 4.0, 6.0);
+                double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+                if(totalConnectReads <= minimumConnection){
+                    break;
+                }
+                if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection ) {
+                    if(std::find(prepassPosition.begin(), prepassPosition.end(), pos1) == prepassPosition.end()){
+                        prepassPosition.push_back(pos1);
+                        weakMethylationPoints3.insert(pos1);
+                        addedPositions3.insert(pos1);
+                    }
+                    if(std::find(prepassPosition.begin(), prepassPosition.end(), nextPos) == prepassPosition.end()){
+                        prepassPosition.push_back(nextPos);
+                        weakMethylationPoints3.insert(nextPos);
+                        addedPositions3.insert(nextPos);
+                    }
+                }
+            }
+            if(!isAdded){
+                weakMethylationPoints3.insert(pos1);
+            }
+        }
+
+        weakMethylationPoints2.clear();
+        addedPositions2.clear();
+    }
+
+    // Ensure passPosition is sorted by position
+    std::sort(prepassPosition.begin(), prepassPosition.end());
+    // Fourth step: Filter positions that do not have good connections to both neighbors
+    for (size_t i = 0; i < prepassPosition.size(); ++i) {
+        int pos = prepassPosition[i];
+        bool hasGoodPrevConnection = false;
+        bool hasGoodNextConnection = false;
+        if(nodeInfo->find(pos) != nodeInfo->end()){
+            if(isSNP(pos)){
+                continue;
+            }
+        }
+                
+        // Check connection with previous position
+        if (i > 0) {
+            int prevPos = prepassPosition[i-1];
+            auto edgeIter = edgeList->find(prevPos);
+            if (edgeIter == edgeList->end()) {
+                continue; // Skip if no edge information
+            }
+            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos);
+            int totalConnectReads = tmp.first + tmp.second;
+            double minimumConnection = std::max(((*nodeInfo)[pos].size() + (*nodeInfo)[prevPos].size()) / 4.0, 6.0); 
+            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+            if(totalConnectReads != 0){
+                
+                if (majorRatio >= params->connectConfidence && totalConnectReads >= /*minimumConnection*/6 ) {
+                    hasGoodPrevConnection = true;
+                }
+            }
+        }
+        
+        // Check connection with next position
+        if (i < prepassPosition.size() - 1 && hasGoodPrevConnection) {
+            int nextPos = prepassPosition[i+1];
+            auto edgeIter = edgeList->find(pos);
+            if (edgeIter == edgeList->end()) {
+                continue; // Skip if no edge information
+            }
+            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
+            int totalConnectReads = tmp.first + tmp.second;
+            double minimumConnection = std::max(((*nodeInfo)[pos].size() + (*nodeInfo)[nextPos].size()) / 4.0, 6.0); 
+            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
+            if(totalConnectReads != 0){
+                if (majorRatio >= params->connectConfidence && totalConnectReads >= 6 ) {
+                    hasGoodNextConnection = true;
+                }
+            }
+        }
+        
+        // Only keep positions with good connections to both neighbors (or edge positions)
+        if ( hasGoodNextConnection || i == 0 || i == prepassPosition.size() - 1) {
+            passPosition.push_back(pos);
+        }
+    }
+    prepassPosition.clear();
+
+}
+
+bool MethylationGraph::isSNP(int position){
+    auto nodeIter = nodeInfo->find(position);
+    if (nodeIter != nodeInfo->end()) {
+        // Iterate over the inner map to check each readID's type
+        for (const auto& nodeType : nodeIter->second) {
+            if (nodeType.second == VariantType::SNP) {
+                return true; // Return true if any type is SNP
+            }
+        }
+    }
+    return false;
+}
+
+bool MethylationGraph::isMethylation(int position){
+    auto nodeIter = nodeInfo->find(position);
+    if (nodeIter != nodeInfo->end()) {
+        // Iterate over the inner map to check each readID's type
+        for (const auto& nodeType : nodeIter->second) {
+            if (nodeType.second == VariantType::SNP) {
+            return false; // Return true if any type is SNP
+            }
+        }
+    }
+    return true;
 }
 
 void MethylationGraph::destroy(){
@@ -615,10 +1144,6 @@ void MethylationGraph::destroy(){
         edgeIter->second->alt->destroy();
         delete edgeIter->second->ref;
         delete edgeIter->second->alt;
-    }
-    
-    for( auto nodeIter = nodeInfo->begin() ; nodeIter != nodeInfo->end() ; nodeIter++ ){
-        delete nodeIter->second;
     }
     
     for( auto nodeIter = forwardModNode->begin() ; nodeIter != forwardModNode->end() ; nodeIter++ ){
@@ -631,6 +1156,416 @@ void MethylationGraph::destroy(){
     
     delete nodeInfo;
     delete edgeList;
-    delete forwardModNode;
-    delete reverseModNode;
 }
+
+MethSnpParser::MethSnpParser(ModCallParameters &in_params):commandLine(false), hasSnpData(false){
+    chrVariant = new std::map<std::string, std::map<int, RefAlt> >;
+    
+    params = &in_params;
+    
+    // Check if SNP file is provided
+    if(params->snpFile.empty()) {
+        std::cerr << "No SNP file provided, running without SNP variants.";
+        return; 
+    }
+    
+    // open vcf file
+    htsFile * inf = bcf_open(params->snpFile.c_str(), "r");
+    if(inf == nullptr) {
+        std::cerr << "Warning: Could not open SNP file " << params->snpFile << ", running without SNP variants.";
+        return;
+    }
+    
+    // read header
+    bcf_hdr_t *hdr = bcf_hdr_read(inf);
+    if(hdr == nullptr) {
+        std::cerr << "Warning: Could not read SNP file header, running without SNP variants.";
+        bcf_close(inf);
+        return;
+    }
+    // counters
+    int nseq = 0;
+    // report names of all the sequences in the VCF file
+    const char **seqnames = NULL;
+    // chromosome idx and name
+    seqnames = bcf_hdr_seqnames(hdr, &nseq);
+    // store chromosome
+    for (int i = 0; i < nseq; i++) {
+        // bcf_hdr_id2name is another way to get the name of a sequence
+        chrName.emplace_back(seqnames[i]);
+    }
+    // set all sample string
+    std::string allSmples = "-";
+    // limit the VCF data to the sample name passed in
+    int is_file = bcf_hdr_set_samples(hdr, allSmples.c_str(), 0);
+    if( is_file != 0 ){
+        std::cout << "error or a positive integer if the list contains samples not present in the VCF header\n";
+    }
+
+    // struct for storing each record
+    bcf1_t *rec = bcf_init();
+    int ngt_arr = 0;
+    int ngt = 0;
+    int *gt     = NULL;
+    
+    // loop vcf line 
+    while (bcf_read(inf, hdr, rec) == 0) {
+        // snp
+        if (bcf_is_snp(rec)) {
+            ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
+
+            if(ngt<0){
+                std::cerr<< "pos " << rec->pos << " missing GT value" << "\n";
+                exit(1);
+            }
+            
+            // just phase hetero SNP
+            if ( (gt[0] == 2 && gt[1] == 4) || // 0/1
+                 (gt[0] == 4 && gt[1] == 2) || // 1/0
+                 (gt[0] == 2 && gt[1] == 5) || // 0|1
+                 (gt[0] == 4 && gt[1] == 3)    // 1|0 
+                ) {
+                
+                // get chromosome string
+                std::string chr = seqnames[rec->rid];
+                // position is 0-base
+                int variantPos = rec->pos;
+                // get r alleles
+                RefAlt tmp;
+                tmp.Ref = rec->d.allele[0]; 
+                tmp.Alt = rec->d.allele[1];
+                
+                //prevent the MAVs calling error which makes the GT=0/1
+                if ( rec->d.allele[1][2] != '\0' ){
+                    continue;
+                }
+                
+                // record 
+                (*chrVariant)[chr][variantPos] = tmp;
+            }
+        }
+    }
+    
+    // Clean up resources
+    if(gt) free(gt);
+    bcf_destroy(rec);
+    bcf_hdr_destroy(hdr);
+    bcf_close(inf);
+    
+    // Set successful loading flag
+    hasSnpData = true;
+    std::cerr << "Successfully loaded SNP variants from " << params->snpFile << "\n";
+}
+
+void MethSnpParser::parserProcess(std::string &input) {
+}
+
+MethSnpParser::~MethSnpParser() {
+    delete chrVariant;
+}
+
+bool MethSnpParser::hasValidSnpData() const {
+    return hasSnpData;
+}
+
+
+void MethSnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult) {
+    //header
+    if( input.substr(0, 2) == "##" ){
+        // avoid double definition
+        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
+            ps_def = true;
+        }
+        resultVcf << input << "\n";
+    }
+    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
+        // format line 
+        if( commandLine == false ){
+            if(ps_def == false){
+                resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
+                ps_def = true;
+            }
+            resultVcf << "##longphaseVersion=" << params->version << "\n";
+            resultVcf << "##commandline=\"" << params->command << "\"\n";
+            commandLine = true;
+        }
+        resultVcf << input << "\n";
+    }
+    else{
+        std::istringstream iss(input);
+        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+
+        if( fields.size() == 0 )
+            return;
+
+        int pos = std::stoi( fields[1] );
+        int posIdx = pos - 1 ;
+        std::string key = fields[0] + "_" + std::to_string(posIdx);
+
+        PhasingResult::iterator psElementIter =  phasingResult.find(key);
+
+        // PS flag already exist, erase PS info
+        if( fields[8].find("PS")!= std::string::npos ){
+
+            // find PS flag
+            int colon_pos = 0;
+            int ps_pos = fields[8].find("PS");
+            for(int i =0 ; i< ps_pos ; i++){
+                if(fields[8][i]==':')
+                    colon_pos++;
+            }
+                                
+            // erase PS flag
+            if( fields[8].find(":",ps_pos+1) != std::string::npos ){
+                fields[8].erase(ps_pos, 3);
+            }
+            else{
+                fields[8].erase(ps_pos - 1, 3);
+            }
+                            
+            // find PS value start
+            int current_colon = 0;
+            int ps_start = 0;
+            for(unsigned int i =0; i < fields[9].length() ; i++){
+                if( current_colon >= colon_pos )
+                    break;
+                if(fields[9][i]==':')
+                    current_colon++;  
+                ps_start++;
+            }
+                            
+            // erase PS value
+            if( fields[9].find(":",ps_start+1) != std::string::npos ){
+                int ps_end_pos = fields[9].find(":",ps_start+1);
+                fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
+            }
+            else{
+                fields[9].erase(ps_start-1, fields[9].length() - ps_start + 1);
+            }
+        }
+        // reset GT flag
+        if( fields[8].find("GT")!= std::string::npos ){
+            // find GT flag
+            int colon_pos = 0;
+            int gt_pos = fields[8].find("GT");
+            for(int i =0 ; i< gt_pos ; i++){
+                if(fields[8][i]==':')
+                    colon_pos++;
+            }
+            // find GT value start
+            int current_colon = 0;
+            int modify_start = 0;
+            for(unsigned int i =0; i < fields[9].length() ; i++){
+                if( current_colon >= colon_pos )
+                    break;
+                if(fields[9][i]==':')
+                    current_colon++;  
+                modify_start++;
+            }
+            if(fields[9][modify_start+1] == '|'){
+                // direct modify GT value
+                if(fields[9][modify_start] > fields[9][modify_start+2]){
+                    fields[9][modify_start+1] = fields[9][modify_start];
+                    fields[9][modify_start] = fields[9][modify_start+2];
+                    fields[9][modify_start+2] =fields[9][modify_start+1];
+                }
+                fields[9][modify_start+1] = '/';
+            }   
+        }
+
+        // Check if the variant is extracted from this VCF
+        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+        
+        // this pos is phase
+        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
+            // add PS flag and value
+            fields[8] = fields[8] + ":PS";
+            fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
+                        
+            // find GT flag
+            int colon_pos = 0;
+            int gt_pos = fields[8].find("GT");
+            for(int i =0 ; i< gt_pos ; i++){
+                if(fields[8][i]==':')
+                    colon_pos++;
+                }
+            // find GT value start
+            int current_colon = 0;
+            int modify_start = 0;
+            for(unsigned int i =0; i < fields[9].length() ; i++){
+                if( current_colon >= colon_pos )
+                    break;
+                if(fields[9][i]==':')
+                    current_colon++;  
+                modify_start++;
+            }
+            // direct modify GT value
+            fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
+            fields[9][modify_start+1] = '|';
+            fields[9][modify_start+2] = (*psElementIter).second.RAstatus[2];
+        }
+        // this pos has not been phased
+        else{
+            // add PS flag and value
+            fields[8] = fields[8] + ":PS";
+            fields[9] = fields[9] + ":.";
+        }
+                    
+        for(std::vector<std::string>::iterator fieldIter = fields.begin(); fieldIter != fields.end(); ++fieldIter){
+            if( fieldIter != fields.begin() )
+                resultVcf<< "\t";
+            resultVcf << (*fieldIter);
+        }
+        resultVcf << "\n";
+    }
+}
+
+std::map<int, RefAlt> MethSnpParser::getVariants(std::string chrName) {
+    std::map<int, RefAlt> targetVariants;
+    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
+    
+    if( chrIter != chrVariant->end() )
+        targetVariants = (*chrIter).second;
+    
+    return targetVariants;
+}
+
+std::map<int, RefAlt> MethSnpParser::getVariants_markindel(std::string chrName, const std::string &ref) {
+    std::map<int, RefAlt> targetVariants;
+    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
+
+    //Mark the indel which lies in the tandem repeat
+    if (chrIter != chrVariant->end()) {
+        // Accessing the inner map using chrIter->second and iterating over it
+        for ( auto innerIter = chrIter->second.begin(); innerIter != chrIter->second.end(); innerIter++ ) {
+            int variant_pos = innerIter->first;      // Accessing the variant_pos of the inner map
+            RefAlt variant_info = innerIter->second; // Accessing the variant_info of the inner map
+            int ref_pos = variant_pos ;
+	        bool danger = false ;
+
+            std::string repeat = ref.substr(ref_pos + 1, 2) ; // get the 2 words string in the reference which behind the indel position
+            int i = 0 ;
+	        //check if there has 2 words tandem repeat in the reference
+            while ( i < 5 && (variant_info.Ref.length()>1 ||variant_info.Alt.length()>1) /*&& repeat[0]!=repeat[1]*/ ) {
+                if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2] ) {
+                    break ;
+                }
+
+                ref_pos = ref_pos + 2 ;
+                i++ ;
+            }
+
+	    // set the dnager to true if the repeat word repeats at least five times
+	    if ( i == 5 ) danger = true ;
+
+            innerIter->second.is_danger = danger ;
+
+        }
+
+        targetVariants = (*chrIter).second;
+    }
+    else {
+        // Handle the case where chrName doesn't exist in chrVariant
+    }
+
+    return targetVariants;
+}
+
+std::vector<std::string> MethSnpParser::getChrVec() {
+    return chrName;
+}
+
+int MethSnpParser::getLastSNP(std::string chrName) {
+    std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
+    // this chromosome not exist in this file. 
+    if(chrVariantIter == chrVariant->end())
+        return -1;
+    // get last SNP
+    std::map< int, RefAlt >::reverse_iterator lastVariantIter = (*chrVariantIter).second.rbegin();
+    // there are no SNPs on this chromosome
+    if(lastVariantIter == (*chrVariantIter).second.rend())
+        return -1;
+    return (*lastVariantIter).first;
+}
+
+void MethSnpParser::writeResult(PhasingResult phasingResult) {
+    if( params->snpFile.find("gz") != std::string::npos ){
+        // .vcf.gz 
+        compressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
+    }
+    else if( params->snpFile.find("vcf") != std::string::npos ){
+        // .vcf
+        unCompressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
+    }
+    return;
+}
+
+bool MethSnpParser::findSNP(std::string chr, int position) {
+    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chr);
+    // empty chromosome
+    if( chrIter == chrVariant->end() )
+        return false;
+    
+    std::map<int, RefAlt>::iterator posIter = (*chrVariant)[chr].find(position);
+    // empty position
+    if( posIter == (*chrVariant)[chr].end() )
+        return false;
+        
+    return true;
+}
+
+void MethSnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariantVec, std::string &chr_reference) {
+    // pos, <allele, <strand, True>
+    std::map<int, std::map<int, std::map<int, bool> > > posAlleleStrand;
+    std::map< int, bool > methylation;
+
+    // Filter SNPs that are not easy to phasing due to homopolymer
+    // get variant list
+    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter =  chrVariant->find(chr);
+    std::map< int, bool > errorProneSNP;
+    
+    if( chrIter != chrVariant->end() ){
+        std::map<int, int> consecutiveAllele;
+        // iter all SNP and tag homopolymer
+        for(std::map<int, RefAlt>::iterator posIter = (*chrIter).second.begin(); posIter != (*chrIter).second.end(); posIter++ ){
+            consecutiveAllele[(*posIter).first] = homopolymerLength((*posIter).first, chr_reference);
+        }
+        std::map<int, RefAlt>::iterator currSNPIter = (*chrIter).second.begin();
+        std::map<int, RefAlt>::iterator nextSNPIter = std::next(currSNPIter,1);
+        // check whether each SNP pair falls in an area that is not easy to phasing
+        while( currSNPIter != (*chrIter).second.end() && nextSNPIter != (*chrIter).second.end() ){
+            int currPos = (*currSNPIter).first;
+            int nextPos = (*nextSNPIter).first;
+            // filter one of SNP if this SNP pair falls in homopolymer and distance<=2
+            if( consecutiveAllele[currPos] >= 3 && consecutiveAllele[nextPos] >= 3 && std::abs(currPos-nextPos)<=2 ){
+                errorProneSNP[nextPos]=true;
+                nextSNPIter = (*chrIter).second.erase(nextSNPIter);
+                continue;
+            }
+            
+            currSNPIter++;
+            nextSNPIter++;
+        }
+        
+    }
+    
+    // iter all reads
+    for( std::vector<ReadVariant>::iterator readSNPVecIter = readVariantVec.begin() ; readSNPVecIter != readVariantVec.end() ; readSNPVecIter++ ){
+        // iter all SNPs in this read
+        for(std::vector<Variant>::iterator variantIter = (*readSNPVecIter).variantVec.begin() ; variantIter != (*readSNPVecIter).variantVec.end() ; ){
+            std::map< int, bool >::iterator delSNPIter = methylation.find((*variantIter).position);
+            std::map< int, bool >::iterator homoIter = errorProneSNP.find((*variantIter).position);
+            
+            if( delSNPIter != methylation.end() ){
+                variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
+            }
+            else if( homoIter != errorProneSNP.end() ){
+                variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
+            }
+            else{
+                variantIter++;
+            }
+        }
+    }
+}
+

--- a/ModCallProcess.h
+++ b/ModCallProcess.h
@@ -7,6 +7,7 @@ struct ModCallParameters
 {
     int numThreads;
     std::string fastaFile;
+    std::string snpFile;
     std::string resultPrefix;
     std::vector<std::string> bamFileVec;
     float modThreshold;

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -342,7 +342,7 @@ std::map<int, RefAlt> SnpParser::getVariants_markindel(std::string chrName, cons
             int variant_pos = innerIter->first;      // Accessing the variant_pos of the inner map
             RefAlt variant_info = innerIter->second; // Accessing the variant_info of the inner map
             int ref_pos = variant_pos ;
-	    bool danger = false ;
+	        bool danger = false ;
 
             std::string repeat = ref.substr(ref_pos + 1, 2) ; // get the 2 words string in the reference which behind the indel position
             int i = 0 ;
@@ -977,7 +977,6 @@ BamParser::BamParser(std::string inputChrName, std::vector<std::string> inputBam
     // set current chromosome MOD map
     (*currentMod) = modFile.getVariants(chrName);
     firstModIter = currentMod->begin();
-    
 }
 
 BamParser::~BamParser(){
@@ -1124,7 +1123,7 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
                         // -3 : reverse strand
                         int strand = ( bam_is_rev(&aln) ? -3 : -2);
                         int allele = ((*readIter).second.is_modify ? 0 : 1) ;
-                        Variant *tmpVariant = new Variant(modPos, allele, strand );
+                        Variant *tmpVariant = new Variant(modPos, allele, strand, VariantType::MOD);
                         // push mod into result vector
                         (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
                         delete tmpVariant;
@@ -1148,7 +1147,7 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
                 }
                 // use quality -1 to identify SVs
                 // push this SV to vector
-                Variant *tmpVariant = new Variant(svPos, allele, -1 );
+                Variant *tmpVariant = new Variant(svPos, allele, -1, VariantType::SV);
                 (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
                 delete tmpVariant;
                 // next SV iter 
@@ -1234,7 +1233,7 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
             
                     if( allele != -1 ){
                         // record snp result
-                        Variant *tmpVariant = new Variant(variantPos, allele, base_q);
+                        Variant *tmpVariant = new Variant(variantPos, allele, base_q, VariantType::SNP);
                         (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
                         delete tmpVariant;                        
                     }
@@ -1317,7 +1316,7 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
                         }
                         
                         if(allele != -1){
-                            Variant *tmpVariant = new Variant((*currentVariantIter).first, allele, base_q);
+                            Variant *tmpVariant = new Variant((*currentVariantIter).first, allele, base_q, VariantType::SNP);
                             (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
                             currentVariantIter++;
                             delete tmpVariant;
@@ -1338,11 +1337,11 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
             getClip(ref_pos, i, cigar_oplen, clipCount);
         }
         // 5: hard clipping (clipped sequences NOT present in SEQ)
-	else if( cigar_op == 5 ){
+	    else if( cigar_op == 5 ){
             getClip(ref_pos, i, cigar_oplen, clipCount);
         }
-	// 6: padding (silent deletion from padded reference)
-	else if(cigar_op == 6 ){
+	    // 6: padding (silent deletion from padded reference)
+	    else if(cigar_op == 6 ){
 
         }
         else{
@@ -1353,7 +1352,6 @@ void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<
 
     if( (*tmpReadResult).variantVec.size() > 0 )
       readVariantVec.push_back((*tmpReadResult));
-    
     delete tmpReadResult;
 }
 

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -10,7 +10,7 @@
 #include <htslib/thread_pool.h>
 #include <htslib/vcf.h>
 #include <htslib/vcfutils.h>
-
+#include "ModCallProcess.h"
 #include <zlib.h>
 
 struct RefAlt{
@@ -70,7 +70,7 @@ class SnpParser : public BaseVairantParser{
     public:
     
         SnpParser(PhasingParameters &in_params);
-        ~SnpParser();
+        ~SnpParser();     
             
         std::map<int, RefAlt> getVariants(std::string chrName);  
 

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -473,7 +473,7 @@ void VairiantGraph::edgeConnectResult(){
     delete phasedBlocks;
 }
 
-VairiantGraph::VairiantGraph(std::string &in_ref, PhasingParameters &in_params){
+VairiantGraph::VairiantGraph(std::string &in_ref, PhasingParameters &in_params, std::string &in_chrName){
     params=&in_params;
     ref=&in_ref;
     totalVariantInfo = new std::map<int,ReadBaseMap*>;
@@ -482,6 +482,7 @@ VairiantGraph::VairiantGraph(std::string &in_ref, PhasingParameters &in_params){
     subNodeHP = new std::map<PosAllele,int>;
     variantType = new std::map<int,int>;
     readHpMap = new std::map<std::string,int>;
+    chrName = &in_chrName;
 }
 
 VairiantGraph::~VairiantGraph(){
@@ -777,7 +778,7 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
             in_readVariant[saveIter++]=in_readVariant[nowDelIter++];
         }
     }
-    in_readVariant.erase( std::next(in_readVariant.begin(), saveIter), in_readVariant.end());
+    in_readVariant.erase( std::next(in_readVariant.begin(), saveIter), in_readVariant.end()); 
     
     CnvStatistics cnvStats;
     //calculate the mismatch rate of the cnv
@@ -1101,7 +1102,7 @@ void VairiantGraph::phasingProcess(){
 
 Clip::Clip(std::string &chr, ClipCount &clipCount){
     this->chr = chr;
-    getCNVInterval(clipCount);
+    getCNVInterval(clipCount, chr);
 }
 
 Clip::~Clip(){
@@ -1124,7 +1125,7 @@ void Clip::updateThreshold(int upCount){
     }
 }
 
-void Clip::getCNVInterval(ClipCount &clipCount){
+void Clip::getCNVInterval(ClipCount &clipCount, std::string &chrName){
     int upCount = 0;
     int downCount = 0;
     int AreaSize = 30000;

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -47,7 +47,7 @@ class Clip{
         Clip(std::string &chr, ClipCount &inClipCount);
         ~Clip();
         std::vector<std::pair<int, int>> cnvVec;
-        void getCNVInterval(ClipCount &clipCount);
+        void getCNVInterval(ClipCount &clipCount, std::string &chr);
         PosVec detectLOH(SnpParser &snpMap);
         std::string getChr() const { return chr;}
 };
@@ -135,6 +135,7 @@ struct CnvStatistics{
 class VairiantGraph{
     
     private:
+        std::string *chrName;
         PhasingParameters *params;
         std::string *ref;
         std::vector<std::string> dotResult;
@@ -180,7 +181,7 @@ class VairiantGraph{
 
     public:
     
-        VairiantGraph(std::string &ref, PhasingParameters &params);
+        VairiantGraph(std::string &ref, PhasingParameters &params, std::string &chrName);
         ~VairiantGraph();
     
         void addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip);

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -90,7 +90,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
         
         std::time_t chrbegin = time(NULL);
         
-        // get lase SNP variant position
+        // get last SNP variant position
         int lastSNPpos = snpFile.getLastSNP((*chrIter));
         // therer is no variant on SNP file. 
         if( lastSNPpos == -1 ){
@@ -120,10 +120,11 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
             continue;
         }
         Clip *clip = new Clip((*chrIter), clipCount);
-        clip->getCNVInterval(clipCount);
+        clip->getCNVInterval(clipCount, (*chrIter));
+        
 
         // create a graph object and prepare to phasing.
-        VairiantGraph *vGraph = new VairiantGraph(chr_reference, params);
+        VairiantGraph *vGraph = new VairiantGraph(chr_reference, params, (*chrIter));
         // trans read-snp info to edge info
         vGraph->addEdge(readVariantVec, *clip);
         // run main algorithm

--- a/Util.h
+++ b/Util.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <omp.h>
 #include <numeric> 
+#include <set>
 
 struct PhasingElement{
     // i.e. 0|1  or   1|0
@@ -51,17 +52,25 @@ void setPhasingNumThreads(const int& defaultChrThreads,const int& availableThrea
  */
 void setModcallNumThreads(const int& availableThreads,  int& chrNumThreads, int& bamParserNumThreads);
 
+enum VariantType{
+    MOD = 0,
+    SNP = 1,
+    INDEL = 2,
+    SV = 3
+};
 
 // use for parsing
 struct Variant{
-    Variant(int position, int allele, int quality):
+    Variant(int position, int allele, int quality, VariantType type):
     position(position), 
     allele(allele), 
-    quality(quality){};
+    quality(quality),
+    type(type){};
     
     int position;
     int allele;
     int quality;
+    VariantType type;
     bool underHomopolymer;
 };
 


### PR DESCRIPTION
## Summary of Changes
1. **ModCall Mode Update**
   - Added a new parameter `-s` for providing an input SNP file.
   - Now supports **two ModCall modes**:
     - **SNP-based mode** (when `-s` is used): Determines methylation calls based on the linkage between methylation sites and SNPs.
     - **Methylation-only mode** (when `-s` is not used): Determines methylation calls based solely on the linkage between methylation sites.
   
2. **Graph Structure Optimization**
   - Merged the forward and reverse strand graphs into a single combined graph.
   - Reduced memory usage by avoiding separate graphs for each strand.

---

## Experimental Results

### SNP-Methylation co-phasing

#### Switch Error Values
| Mode | 10x | 20x | 30x | 40x | 50x | 60x |
|------|-----|-----|-----|-----|-----|-----|
| SNP-Only phasing | `1,082` | `1,155` | `1,131` | `1,156` | `1,163` | `1,162` |
| Methylation-only mode | `1,178` | `1,252` | `1,235` | `1,230` | `1,225` | `1,235` |
| SNP-based mode | `1,095` | `1,183` | `1,149` | `1,167` | `1,170` | `1,179` |

---

#### N50 Values
| Mode | 10x | 20x | 30x | 40x | 50x | 60x |
|------|-----|-----|-----|-----|-----|-----|
| SNP-Only phasing | `807,877` | `1,674,138` | `2,043,162` | `2,353,055` | `2,659,549` | `2,864,135` |
| Methylation-only mode | `927,863` | `2,539,330` | `3,473,784` | `4,508,406` | `4,688,303` | `5,169,341` |
| SNP-based mode | `817,828` | `1,808,539` | `2,265,463` | `2,612,076` | `2,921,767` | `3,131,562` |
