### PR TITLE
refactor : extract helper functions and remove dead code

### DIFF
--- a/HaplotagProcess.cpp
+++ b/HaplotagProcess.cpp
@@ -1,299 +1,479 @@
 #include "HaplotagProcess.h"
 
+namespace {
+
+enum class VariantInputKind {
+    Compressed,
+    Uncompressed,
+    Unsupported
+};
+
+VariantInputKind classifyVariantInput(const std::string &variantFile)
+{
+    if( variantFile.find("gz") != std::string::npos ){
+        return VariantInputKind::Compressed;
+    }
+    if( variantFile.find("vcf") != std::string::npos ){
+        return VariantInputKind::Uncompressed;
+    }
+    return VariantInputKind::Unsupported;
+}
+
+template <typename Callback>
+void readGzLines(const std::string &variantFile, Callback callback)
+{
+    gzFile file = gzopen(variantFile.c_str(), "rb");
+    if(!file){
+        std::cerr<< "Fail to open vcf: " << variantFile << "\n";
+        return;
+    }
+
+    int buffer_size = 1048576; // 1M
+    char* buffer = (char*) malloc(buffer_size);
+    if(!buffer){
+        std::cerr<<"Failed to allocate buffer\n";
+        exit(EXIT_FAILURE);
+    }
+    char* offset = buffer;
+        
+    while(true) {
+        int len = buffer_size - (offset - buffer);
+        if (len == 0){
+            buffer_size *= 2; // Double the buffer size
+            char* new_buffer = (char*) realloc(buffer, buffer_size);
+            if(!new_buffer){
+                std::cerr<<"Failed to allocate buffer\n";
+                free(buffer);
+                exit(EXIT_FAILURE);
+            }
+            buffer = new_buffer;
+            offset = buffer + buffer_size / 2; // Update the offset pointer to the end of the old buffer
+            len = buffer_size - (offset - buffer);
+        }
+
+        len = gzread(file, offset, len);
+        if (len == 0) break;    
+        if (len <  0){ 
+            int err;
+            fprintf (stderr, "Error: %s.\n", gzerror(file, &err));
+            exit(EXIT_FAILURE);
+        }
+
+        char* cur = buffer;
+        char* end = offset+len;
+        for (char* eol; (cur<end) && (eol = std::find(cur, end, '\n')) < end; cur = eol + 1)
+        {
+            std::string input = std::string(cur, eol);
+            callback(input);
+        }
+        // any trailing data in [eol, end) now is a partial line
+        offset = std::copy(cur, end, buffer);
+    }
+    gzclose (file);
+    free(buffer);
+}
+
+template <typename Callback>
+void readPlainLines(const std::string &variantFile, Callback callback)
+{
+    std::ifstream file(variantFile);
+    if (!file.is_open()) {
+        std::cerr << "Fail to open vcf: " << variantFile << "\n";
+        exit(1);
+    }
+    std::string input;
+    while (!file.eof()) {           // preserve original eof() anti-pattern; line emission sequence must remain identical
+        std::getline(file, input);
+        callback(input);
+    }
+}
+
+// Extracts the colon-delimited value starting at fieldStart in sample.
+std::string extractFieldValue(const std::string &sample, int fieldStart)
+{
+    size_t next_colon = sample.find(':', (size_t)fieldStart + 1);
+    if (next_colon != std::string::npos)
+        return sample.substr((size_t)fieldStart, next_colon - (size_t)fieldStart);
+    return sample.substr((size_t)fieldStart);
+}
+
+// Returns 1 (0|1: ALT on HP2), 0 (1|0: ALT on HP1), or -1 (other).
+int resolveHaplotypeDirection(char gt0, char gt2)
+{
+    if (gt0 == '0' && gt2 == '1') return 1;
+    if (gt0 == '1' && gt2 == '0') return 0;
+    return -1;
+}
+
+std::pair<int, int> scoreIndelSupport(bool readHasIndel, int hp1Length, int hp2Length)
+{
+    if (readHasIndel) {
+        if (hp1Length != 1 && hp2Length == 1)
+            return std::make_pair(1, 0);
+        if (hp1Length == 1 && hp2Length != 1)
+            return std::make_pair(0, 1);
+    }
+    else {
+        if (hp1Length != 1 && hp2Length == 1)
+            return std::make_pair(0, 1);
+        if (hp1Length == 1 && hp2Length != 1)
+            return std::make_pair(1, 0);
+    }
+    return std::make_pair(0, 0);
+}
+
+}
 
 void HaplotagProcess::variantParser(std::string variantFile){
 
-    if( variantFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressParser(variantFile);
+    VariantInputKind inputKind = classifyVariantInput(variantFile);
+
+    switch(inputKind){
+        case VariantInputKind::Compressed:
+            compressParser(variantFile);
+            break;
+        case VariantInputKind::Uncompressed:
+            unCompressParser(variantFile);
+            break;
+        case VariantInputKind::Unsupported:
+            std::cerr<<"file: "<< variantFile << "\nnot vcf file. please check filename extension\n";
+            exit(EXIT_FAILURE);
     }
-    else if( variantFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressParser(variantFile);
-    }
-    else{
-        std::cerr<<"file: "<< variantFile << "\nnot vcf file. please check filename extension\n";
-        exit(EXIT_FAILURE);
-    }
-    return;
 }
 
 void HaplotagProcess::compressParser(std::string &variantFile){
-    gzFile file = gzopen(variantFile.c_str(), "rb");
     if(variantFile=="")
         return;
-    if(!file){
-        std::cerr<< "Fail to open vcf: " << variantFile << "\n";
-    }
-    else{  
-        int buffer_size = 1048576; // 1M
-        char* buffer = (char*) malloc(buffer_size);
-        if(!buffer){
-            std::cerr<<"Failed to allocate buffer\n";
-            exit(EXIT_FAILURE);
-        }
-        char* offset = buffer;
-            
-        while(true) {
-            int len = buffer_size - (offset - buffer);
-            if (len == 0){
-                buffer_size *= 2; // Double the buffer size
-                char* new_buffer = (char*) realloc(buffer, buffer_size);
-                if(!new_buffer){
-                    std::cerr<<"Failed to allocate buffer\n";
-                    free(buffer);
-                    exit(EXIT_FAILURE);
-                }
-                buffer = new_buffer;
-                offset = buffer + buffer_size / 2; // Update the offset pointer to the end of the old buffer
-                len = buffer_size - (offset - buffer);
-            }
 
-            len = gzread(file, offset, len);
-            if (len == 0) break;    
-            if (len <  0){ 
-                int err;
-                fprintf (stderr, "Error: %s.\n", gzerror(file, &err));
-                exit(EXIT_FAILURE);
-            }
-
-            char* cur = buffer;
-            char* end = offset+len;
-            for (char* eol; (cur<end) && (eol = std::find(cur, end, '\n')) < end; cur = eol + 1)
-            {
-                std::string input = std::string(cur, eol);
-                parserProcess(input);
-            }
-            // any trailing data in [eol, end) now is a partial line
-            offset = std::copy(cur, end, buffer);
-        }
-        gzclose (file);
-        free(buffer);
-    }    
+    readGzLines(variantFile, [this](std::string &input) {
+        parserProcess(input);
+    });
 }
 
 void HaplotagProcess::unCompressParser(std::string &variantFile){
-    std::ifstream originVcf(variantFile);
-    if(variantFile=="")
+    if (variantFile == "") {
         return;
-    if(!originVcf.is_open()){
-        std::cerr<< "Fail to open vcf: " << variantFile << "\n";
-        exit(1);
     }
-    else{
-        std::string input;
-        while(! originVcf.eof() ){
-            std::getline(originVcf, input);
-            parserProcess(input);
+    readPlainLines(variantFile, [this](std::string &line) {
+        parserProcess(line);
+    });
+}
+
+void HaplotagProcess::parserProcess(std::string &input){
+    if (input.substr(0, 2) == "##") {
+        parseHeaderLine(input);
+        return;
+    }
+    if (input.substr(0, 1) == "#") {
+        return;
+    }
+    parseRecordLine(input);
+}
+
+void HaplotagProcess::parseHeaderLine(const std::string &line){
+    if (!parseSnpFile)
+        return;
+    if (line.find("contig=") != std::string::npos) {
+        int id_start  = line.find("ID=")+3;
+        int id_end    = line.find(",length=");
+        int len_start = id_end+8;
+        int len_end   = line.find(">");
+
+        std::string chr = line.substr(id_start, id_end-id_start);
+        int chrLen = std::stoi(line.substr(len_start, len_end-len_start));
+
+        chrVec.push_back(chr);
+        chrLength[chr] = chrLen;
+    }
+    if (line.substr(0, 16) == "##FORMAT=<ID=PS,") {
+        if (line.find("Type=Integer") != std::string::npos) {
+            integerPS = true;
+        }
+        else if (line.find("Type=String") != std::string::npos) {
+            integerPS = false;
+            std::cerr << "PS type is String. Auto index to integer ... ";
+        }
+        else {
+            std::cerr << "ERROR: not found PS type (Type=Integer or Type=String).\n";
+            exit(EXIT_SUCCESS);
         }
     }
 }
 
-void HaplotagProcess::parserProcess(std::string &input){
-    if( input.substr(0, 2) == "##" && parseSnpFile){
-        if( input.find("contig=")!= std::string::npos ){
-            int id_start  = input.find("ID=")+3;
-            int id_end    = input.find(",length=");
-            int len_start = id_end+8;
-            int len_end   = input.find(">");
-            
-            std::string chr = input.substr(id_start,id_end-id_start);
-            int chrLen = std::stoi( input.substr(len_start,len_end-len_start) );
+void HaplotagProcess::parseRecordLine(const std::string &line){
+    std::istringstream iss(line);
+    std::vector<std::string> fields((std::istream_iterator<std::string>(iss)), std::istream_iterator<std::string>());
 
-            chrVec.push_back(chr);
-            chrLength[chr]=chrLen;
+    if (fields.size() == 0)
+        return;
+
+    // trans to 0-base
+    int pos = std::stoi(fields[1]) - 1;
+
+    // find GT value start (using helper)
+    int modifu_start = findFieldValueStart(fields[8], fields[9], "GT");
+
+    // hetero GT
+    if ((fields[9][modifu_start] != fields[9][modifu_start+2]) && fields[9][modifu_start+1] == '|') {
+        int ps_start = findFieldValueStart(fields[8], fields[9], "PS");
+        std::string psValue = extractFieldValue(fields[9], ps_start);
+        int haploDir = resolveHaplotypeDirection(fields[9][modifu_start], fields[9][modifu_start+2]);
+
+        if (parseSnpFile)  processSnpRecord(fields, pos, haploDir, psValue);
+        if (parseSVFile)   processSvRecord(fields, haploDir);
+        if (parseMODFile)  processModRecord(fields, haploDir);
+    }
+}
+
+void HaplotagProcess::processSnpRecord(const std::vector<std::string> &fields, int pos, int haploDir, const std::string &psValue){
+    std::string chr = fields[0];
+    SnpVariant tmp;
+    tmp.Ref = fields[3];
+    tmp.Alt = fields[4];
+
+    chrVariant[chr][pos] = tmp;
+
+    if (integerPS) {
+        chrVariantPS[chr][pos] = std::stoi(psValue);
+    }
+    else {
+        std::map<std::string, int>::iterator psIter = psIndex.find(psValue);
+        if (psIter == psIndex.end()) {
+            psIndex[psValue] = psIndex.size();
         }
-        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
-            if( input.find("Type=Integer")!= std::string::npos ){
-                integerPS = true;
-            }
-            else if( input.find("Type=String")!= std::string::npos ){
-                integerPS = false;
-                std::cerr<< "PS type is String. Auto index to integer ... ";
-            }
-            else{
-                std::cerr<< "ERROR: not found PS type (Type=Integer or Type=String).\n"; 
-                exit(EXIT_SUCCESS);
-            }
+        chrVariantPS[chr][pos] = psIndex[psValue];
+    }
+
+    if (haploDir == 1) {
+        chrVariantHP1[chr][pos] = fields[3];
+        chrVariantHP2[chr][pos] = fields[4];
+    }
+    else if (haploDir == 0) {
+        chrVariantHP1[chr][pos] = fields[4];
+        chrVariantHP2[chr][pos] = fields[3];
+    }
+}
+
+void HaplotagProcess::processSvRecord(const std::vector<std::string> &fields, int haploDir){
+    std::string chr = fields[0];
+    int start = std::stoi(fields[1]);
+    std::string info = fields[7];
+    size_t svlenPos = info.find("SVLEN=");
+    if (svlenPos != std::string::npos) {
+        svlenPos += 6;
+        size_t semiPos = info.find(';', svlenPos);
+        int svlen = std::stoi(info.substr(svlenPos, semiPos - svlenPos));
+        if (haploDir == 1) {
+            chrRegions[chr].push_back(std::make_tuple(start, svlen, 1));
+        }
+        else if (haploDir == 0) {
+            chrRegions[chr].push_back(std::make_tuple(start, svlen, 0));
         }
     }
-    else if ( input.substr(0, 1) == "#" ){
-        
+}
+
+void HaplotagProcess::processModRecord(const std::vector<std::string> &fields, int haploDir){
+    int read_pos = fields[7].find("MR=");
+    read_pos = fields[7].find("=", read_pos);
+    read_pos++;
+
+    int next_field = fields[7].find(";", read_pos);
+    std::string totalRead = fields[7].substr(read_pos, next_field-read_pos);
+    std::stringstream totalReadStream(totalRead);
+
+    std::string read;
+    while (std::getline(totalReadStream, read, ',')) {
+        auto readIter = readSVHapCount.find(read);
+        if (readIter == readSVHapCount.end()) {
+            readSVHapCount[read][0] = 0;
+            readSVHapCount[read][1] = 0;
+        }
+        readSVHapCount[read][haploDir]++;
     }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+}
 
-        if( fields.size() == 0 )
-            return;
-            
-        // trans to 0-base
-        int pos = std::stoi( fields[1] ) - 1;
-        std::string chr = fields[0];
-                
-        // find GT flag colon
-        int colon_pos = 0;
-        int gt_pos = fields[8].find("GT");
-        for(int i =0 ; i< gt_pos ; i++){
-            if(fields[8][i]==':')
-                colon_pos++;
+std::vector<int> HaplotagProcess::collectLastVariantPos() const {
+    std::vector<int> last_pos;
+    for (auto chr : chrVec) {
+        auto mapIter = chrVariantPS.find(chr);
+        if (mapIter != chrVariantPS.end()) {
+            auto lastVariantIter = mapIter->second.rbegin();
+            if (lastVariantIter != mapIter->second.rend()) {
+                last_pos.push_back(lastVariantIter->second);
+            } else {
+                last_pos.push_back(0);
+            }
+        } else {
+            last_pos.push_back(0);
         }
-        // find GT value start
-        int current_colon = 0;
-        int modifu_start = 0;
-        for(unsigned int i =0; i < fields[9].length() ; i++){
-            if( current_colon >= colon_pos )
-                break;
-            if(fields[9][i]==':')
-                current_colon++;  
-            modifu_start++;
-        }
+    }
+    return last_pos;
+}
 
-        // hetero GT
-        if( (fields[9][modifu_start] != fields[9][modifu_start+2]) && fields[9][modifu_start+1] == '|' ){
-            // find PS flag
-            colon_pos = 0;
-            int ps_pos = fields[8].find("PS");
-            for(int i =0 ; i< ps_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
+std::ofstream* HaplotagProcess::initLogFile(const HaplotagParameters &params) {
+    if (!params.writeReadLog)
+        return NULL;
+
+    std::ofstream *tagResult = new std::ofstream(params.resultPrefix + ".out");
+    if (!tagResult->is_open()) {
+        std::cerr << "Fail to open write file: " << params.resultPrefix + ".out" << "\n";
+        exit(1);
+    }
+    (*tagResult) << "##snpFile:"             << params.snpFile             << "\n";
+    (*tagResult) << "##svFile:"              << params.svFile              << "\n";
+    (*tagResult) << "##bamFile:"             << params.bamFile             << "\n";
+    (*tagResult) << "##resultPrefix:"        << params.resultPrefix        << "\n";
+    (*tagResult) << "##numThreads:"          << params.numThreads          << "\n";
+    (*tagResult) << "##region:"              << params.region              << "\n";
+    (*tagResult) << "##qualityThreshold:"    << params.qualityThreshold    << "\n";
+    (*tagResult) << "##percentageThreshold:" << params.percentageThreshold << "\n";
+    (*tagResult) << "#tagSupplementary:"     << params.tagSupplementary    << "\n";
+    (*tagResult) << "#svWindowsize:"         << params.svWindow            << "\n";
+    (*tagResult) << "#svThreshold:"          << params.svThreshold         << "\n";
+    (*tagResult) << "#Read\t"
+                 << "Chr\t"
+                 << "ReadStart\t"
+                 << "Confidnet(%)\t"
+                 << "Haplotype\t"
+                 << "PhaseSet\t"
+                 << "TotalAllele\t"
+                 << "HP1Allele\t"
+                 << "HP2Allele\t"
+                 << "phasingQuality(PQ)\t"
+                 << "(Variant,HP)\t"
+                 << "(PhaseSet,Variantcount)\n";
+    return tagResult;
+}
+
+void HaplotagProcess::tagChromosome(const std::string &chr,
+                                    const HaplotagParameters &params,
+                                    samFile *in, samFile *out,
+                                    bam_hdr_t *bamHdr, hts_idx_t *idx,
+                                    bam1_t *aln,
+                                    const std::string &chr_reference,
+                                    std::ofstream *tagResult) {
+    std::time_t begin = time(NULL);
+    std::cerr<<"chr: " << chr << " ... " ;
+
+    currentChrVariants = chrVariant[chr];
+    firstVariantIter = currentChrVariants.begin();
+    std::map<int, SnpVariant>::reverse_iterator last = currentChrVariants.rbegin();
+
+    currentchrRegions = chrRegions[chr];
+    firstSVIter = currentchrRegions.begin();
+
+    std::string region = !params.region.empty() ? params.region : chr + ":1-" + std::to_string(chrLength[chr]);
+    hts_itr_t *iter = sam_itr_querys(idx, bamHdr, region.c_str());
+    int result = 0;
+    while ((result = sam_itr_multi_next(in, iter, aln)) >= 0) {
+        totalAlignment++;
+        int flag = aln->core.flag;
+
+        // Intentionally different from phase/modcall filters: uses
+        // qualityThreshold and tagSupplementary; duplicate (0x400) is not
+        // filtered here; supplementary handling is config-driven.
+        if ( aln->core.qual < params.qualityThreshold ){
+            totalUnTagCount++;
+        }
+        else if( (flag & 0x4) != 0 ){
+            totalUnmapped++;
+            totalUnTagCount++;
+        }
+        else if( (flag & 0x100) != 0 ){
+            totalSecondary++;
+            totalUnTagCount++;
+        }
+        else if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
+            totalSupplementary++;
+            totalUnTagCount++;
+        }
+        else if(last == currentChrVariants.rend()){
+            totalUnTagCount++;
+        }
+        else if(int(aln->core.pos) <= (*last).first){
+
+            if( (flag & 0x800) != 0 ){
+                totalSupplementary++;
             }
 
-            // find PS value start
-            current_colon = 0;
-            int ps_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                ps_start++;
-            }
-            
-            std::string psValue;
-            // get PS value
-            if( fields[9].find(":",ps_start+1) != std::string::npos ){
-                int ps_end_pos = fields[9].find(":",ps_start+1);
-                psValue = fields[9].substr(ps_start, ps_end_pos - ps_start);
+            int pqValue = 0;
+            int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue, chr_reference, params.svWindow, params.svThreshold);
+
+            initFlag(aln, "HP");
+            initFlag(aln, "PS");
+            initFlag(aln, "PQ");
+
+            if (haplotype != 0){
+                int psValue = chrVariantPS[chr][(*firstVariantIter).first];
+                bam_aux_append(aln, "HP", 'i', sizeof(haplotype), (uint8_t*) &haplotype);
+                bam_aux_append(aln, "PS", 'i', sizeof(psValue), (uint8_t*) &psValue);
+                bam_aux_append(aln, "PQ", 'i', sizeof(pqValue), (uint8_t*) &pqValue);
+                totalTagCount++;
             }
             else{
-                psValue = fields[9].substr(ps_start, fields[9].length() - ps_start);
-            }
-            
-            // snp file
-            if( parseSnpFile ){
-                RefAlt tmp;
-                tmp.Ref = fields[3]; 
-                tmp.Alt = fields[4];
-
-                chrVariant[chr][pos]=tmp;
-                
-                if(integerPS){
-                    chrVariantPS[chr][pos]=std::stoi(psValue);
-                }
-                else{
-                    std::map<std::string, int>::iterator psIter = psIndex.find(psValue);
-                    
-                    if( psIter == psIndex.end() ){
-                        psIndex[psValue] = psIndex.size();
-                    }
-                    chrVariantPS[chr][pos]=psIndex[psValue];
-                }
-                
-                // record haplotype allele
-                if( fields[9][modifu_start] == '0' && fields[9][modifu_start+2] == '1' ){
-                    chrVariantHP1[chr][pos]=fields[3];
-                    chrVariantHP2[chr][pos]=fields[4];
-                }
-                else if( fields[9][modifu_start] == '1' && fields[9][modifu_start+2] == '0' ){
-                    chrVariantHP1[chr][pos]=fields[4];
-                    chrVariantHP2[chr][pos]=fields[3];
-                }
-            }
-            // sv file
-            if( parseSVFile ){
-                // get read INFO
-                // get SV regions
-                int start = std::stoi(fields[1]);
-                std::string info = fields[7];
-                size_t svlenPos = info.find("SVLEN=");  // get SV length
-                if (svlenPos != std::string::npos)
-                {
-                    svlenPos += 6;
-                    size_t semiPos = info.find(';', svlenPos);
-                    int svlen = std::stoi(info.substr(svlenPos, semiPos - svlenPos));
-                    // Insert SV information into chrRegions
-                    // In which haplotype does SV occur
-                    int svHaplotype;
-
-                    if (fields[9][modifu_start] == '0' && fields[9][modifu_start + 2] == '1')
-                    {
-                        svHaplotype = 1;
-                        chrRegions[chr].push_back(std::make_tuple(start, svlen, svHaplotype));
-                    }
-                    else if (fields[9][modifu_start] == '1' && fields[9][modifu_start + 2] == '0')
-                    {
-                        svHaplotype = 0;
-                        chrRegions[chr].push_back(std::make_tuple(start, svlen, svHaplotype));
-                    }
-                }
-
-            }
-            // mod file
-            if( parseMODFile ){
-                // get read INFO
-                int read_pos = fields[7].find("MR=");
-                read_pos = fields[7].find("=",read_pos);
-                read_pos++;
-                        
-                int next_field = fields[7].find(";",read_pos);
-                std::string totalRead = fields[7].substr(read_pos,next_field-read_pos);
-                std::stringstream totalReadStream(totalRead);
-                
-                int modHaplotype;
-                // In which haplotype does SV occur
-                if( fields[9][modifu_start] == '0' && fields[9][modifu_start+2] == '1' ){
-                    modHaplotype = 1;
-                }
-                else if( fields[9][modifu_start] == '1' && fields[9][modifu_start+2] == '0' ){
-                    modHaplotype = 0;
-                }
-                
-                std::string read;
-                while(std::getline(totalReadStream, read, ','))
-                {
-                   auto readIter = readSVHapCount.find(read);
-                   if(readIter==readSVHapCount.end()){
-                       readSVHapCount[read][0]=0;
-                       readSVHapCount[read][1]=0;
-                   }
-                   readSVHapCount[read][modHaplotype]++;
-                }
+                totalUnTagCount++;
             }
         }
+        else{
+            totalUnTagCount++;
+        }
+
+        result = sam_write1(out, bamHdr, aln);
+    }
+    hts_itr_destroy(iter);
+    std::cerr<< difftime(time(NULL), begin) << "s\n";
+}
+
+void HaplotagProcess::writeUnmappedTail(samFile *in, samFile *out,
+                                        bam_hdr_t *bamHdr, hts_idx_t *idx) {
+    hts_itr_t *iter_unmap = sam_itr_querys(idx, bamHdr, "*");
+    if (iter_unmap == NULL) {
+        std::cerr << "WARN: Cannot create iterator for '*' (unmapped tail)\n";
+    } else {
+        bam1_t *aln_unmap = bam_init1();
+        int r = 0;
+        while ((r = sam_itr_multi_next(in, iter_unmap, aln_unmap)) >= 0) {
+            initFlag(aln_unmap, "HP");
+            initFlag(aln_unmap, "PS");
+            initFlag(aln_unmap, "PQ");
+
+            totalAlignment++;
+            totalUnmapped++;
+            totalUnTagCount++;
+
+            int wr = sam_write1(out, bamHdr, aln_unmap);
+            if (wr < 0) {
+                std::cerr << "ERROR: Failed to write unmapped read: "
+                          << bam_get_qname(aln_unmap) << "\n";
+            }
+        }
+        bam_destroy1(aln_unmap);
+        hts_itr_destroy(iter_unmap);
+    }
+}
+
+void HaplotagProcess::resolveRegionScope(const HaplotagParameters &params){
+    if (params.region.empty())
+        return;
+
+    auto colonPos = params.region.find(":");
+    std::string regionChr = (colonPos != std::string::npos)
+        ? params.region.substr(0, colonPos)
+        : params.region;
+
+    auto chrVecIter = std::find(chrVec.begin(), chrVec.end(), regionChr);
+    if (chrVecIter != chrVec.end()) {
+        chrVec = std::vector<std::string>{regionChr};
+    } else {
+        std::cerr << "ERROR: Incorrect chromosome for input region\n" << std::endl;
+        exit(1);
     }
 }
 
 void HaplotagProcess::tagRead(HaplotagParameters &params){
 
-    // update chromosome processing based on region
-    if (!params.region.empty()) {
-        auto colonPos = params.region.find(":");
-        std::string regionChr;
-        if (colonPos != std::string::npos) {
-            regionChr = params.region.substr(0, colonPos);
-        }
-        else {
-            regionChr = params.region;
-        }
-        auto chrVecIter = std::find(chrVec.begin(), chrVec.end(), regionChr);
-        if (chrVecIter != chrVec.end()) {
-            chrVec = std::vector<std::string>{regionChr};
-        } else {
-            std::cerr << "ERROR: Incorrect chromosome for input region\n" << std::endl;
-            exit(1);
-        }
-    }
+    resolveRegionScope(params);
+
     // input file management
     std::string openBamFile = params.bamFile;
     // open bam file
@@ -329,56 +509,12 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
         exit(1);
     }
 
-    // record reference last variant pos
-    std::vector<int> last_pos;
-    for( auto chr : chrVec ){
-        auto lastVariantIter = chrVariantPS[chr].rbegin();
-        if( lastVariantIter != chrVariantPS[chr].rend() ){
-            last_pos.push_back(lastVariantIter->second);
-        }
-        else{
-            last_pos.push_back(0);
-        }
-    }
+    std::vector<int> last_pos = collectLastVariantPos();
 
     // reference fasta parser
     FastaParser fastaParser(params.fastaFile, chrVec, last_pos, params.numThreads);
 
-    // write tag read detail information
-    std::ofstream *tagResult=NULL;
-    if(params.writeReadLog){
-        tagResult=new std::ofstream(params.resultPrefix+".out");
-        if(!tagResult->is_open()){
-            std::cerr<< "Fail to open write file: " << params.resultPrefix+".out" << "\n";
-            exit(1);
-        }
-        else{
-            (*tagResult) << "##snpFile:"             << params.snpFile             << "\n";
-            (*tagResult) << "##svFile:"              << params.svFile              << "\n";
-            (*tagResult) << "##bamFile:"             << params.bamFile             << "\n";
-            (*tagResult) << "##resultPrefix:"        << params.resultPrefix        << "\n";
-            (*tagResult) << "##numThreads:"          << params.numThreads          << "\n";
-            (*tagResult) << "##region:"              << params.region              << "\n";
-            (*tagResult) << "##qualityThreshold:"    << params.qualityThreshold    << "\n";
-            (*tagResult) << "##percentageThreshold:" << params.percentageThreshold << "\n";
-            (*tagResult) << "#tagSupplementary:"     << params.tagSupplementary    << "\n";
-            (*tagResult) << "#svWindowsize:"         << params.svWindow            << "\n";
-            (*tagResult) << "#svThreshold:"          << params.svThreshold         << "\n";
-            (*tagResult) << "#Read\t"
-                         << "Chr\t"
-                         << "ReadStart\t"
-                         << "Confidnet(%)\t"
-                         << "Haplotype\t"
-                         << "PhaseSet\t"
-                         << "TotalAllele\t"
-                         << "HP1Allele\t"
-                         << "HP2Allele\t"
-                         << "phasingQuality(PQ)\t"
-                         << "(Variant,HP)\t"
-                         << "(PhaseSet,Variantcount)\n";
-
-        }
-    }
+    std::ofstream *tagResult = initLogFile(params);
     // init data structure and get core n
     htsThreadPool threadPool = {NULL, 0};
     // creat thread pool
@@ -393,90 +529,12 @@ void HaplotagProcess::tagRead(HaplotagParameters &params){
 
     // loop all chromosome
     for(auto chr : chrVec ){
-        std::time_t begin = time(NULL);
-        std::cerr<<"chr: " << chr << " ... " ;
-        // records all variants within this chromosome.
-        currentChrVariants = chrVariant[chr];
-        // since each read is sorted based on the start coordinates, to save time, 
-        // firstVariantIter keeps track of the first variant that each read needs to check.
-        firstVariantIter = currentChrVariants.begin();
-        // get the coordinates of the last variant
-        // the tagging process will not be perform if the read's start coordinate are over than last variant.
-        std::map<int, RefAlt>::reverse_iterator last = currentChrVariants.rbegin();
-        
-        // get the current chromosome SV region
-        currentchrRegions = chrRegions[chr];
-        firstSVIter = currentchrRegions.begin();
-        // fetch chromosome string
-        std::string chr_reference = fastaParser.chrString.at(chr);
-        
-        // tagging will be attempted for reads within the specified coordinate region.
-        std::string region = !params.region.empty() ? params.region : chr + ":1-" + std::to_string(chrLength[chr]);
-        hts_itr_t *iter = sam_itr_querys(idx, bamHdr, region.c_str());
-        // iter all reads
-        while ((result = sam_itr_multi_next(in, iter, aln)) >= 0) {
-            totalAlignment++;
-            int flag = aln->core.flag;
-
-            if ( aln->core.qual < params.qualityThreshold ){
-                // mapping quality is lower than threshold
-                totalUnTagCount++;
-            }
-            else if( (flag & 0x4) != 0 ){
-                // read unmapped
-                totalUnmapped++;
-                totalUnTagCount++;
-            }
-            else if( (flag & 0x100) != 0 ){
-                // secondary alignment. repeat.
-                // A secondary alignment occurs when a given read could align reasonably well to more than one place.
-                totalSecondary++;
-                totalUnTagCount++;
-            }
-            else if( (flag & 0x800) != 0 && params.tagSupplementary == false ){
-                // supplementary alignment
-                // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
-                totalSupplementary++;
-                totalUnTagCount++;
-            }
-            else if(last == currentChrVariants.rend()){
-                // skip 
-                totalUnTagCount++;
-            }
-            else if(int(aln->core.pos) <= (*last).first){
-                
-                if( (flag & 0x800) != 0 ){
-                    totalSupplementary++;
-                }
-
-                int pqValue = 0;
-                int haplotype = judgeHaplotype(*bamHdr, *aln, chr, params.percentageThreshold, tagResult, pqValue, chr_reference, params.svWindow, params.svThreshold);
-
-                initFlag(aln, "HP");
-                initFlag(aln, "PS");
-                initFlag(aln, "PQ");
-
-                if (haplotype != 0){
-
-                    int psValue = chrVariantPS[chr][(*firstVariantIter).first];
-                    bam_aux_append(aln, "HP", 'i', sizeof(haplotype), (uint8_t*) &haplotype);
-                    bam_aux_append(aln, "PS", 'i', sizeof(psValue), (uint8_t*) &psValue);
-                    bam_aux_append(aln, "PQ", 'i', sizeof(pqValue), (uint8_t*) &pqValue);
-                    totalTagCount++;
-                }
-                else{
-                    totalUnTagCount++;
-                }
-            }
-            else{
-                totalUnTagCount++;
-            }
-
-            // write this alignment to result bam file
-            result = sam_write1(out, bamHdr, aln);
-        }
-        std::cerr<< difftime(time(NULL), begin) << "s\n";
+        tagChromosome(chr, params, in, out, bamHdr, idx, aln,
+                      fastaParser.chrString.at(chr), tagResult);
     }
+
+    writeUnmappedTail(in, out, bamHdr, idx);
+
     if(tagResult!=NULL){
         (*tagResult).close();
     }
@@ -500,286 +558,181 @@ void HaplotagProcess::initFlag(bam1_t *aln, std::string flag){
     return;
 }
 
-int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue, const std::string &ref_string, int svWindow, double svThreshold){
+void HaplotagProcess::collectSVWindowEvidence(const bam1_t &aln, int cigarIdx, int n_cigar,
+                                              const uint32_t *cigar,
+                                              std::vector<std::tuple<int, int, int> >::iterator svIter,
+                                              int svWindow, double svThreshold)
+{
+    if (svIter == currentchrRegions.end())
+        return;
 
-    int hp1Count = 0;
-    int hp2Count = 0;
-    //record variants on this read
-    std::map<int,int> variantsHP;
-    std::map<int,int> countPS;
+    int sv_start = std::get<0>(*svIter);
+    int sv_length = std::get<1>(*svIter);
+    int sv_end = sv_start + std::abs(sv_length);
+    int svHaplotype = std::get<2>(*svIter);
+    double sv_region = sv_end - sv_start + 1;
 
-    // Skip variants that are to the left of this read
-    while( firstVariantIter != currentChrVariants.end() && (*firstVariantIter).first < aln.core.pos ){
-        firstVariantIter++;
-    }
-    
-    // Skip SVs that are to the left of this read
-    while (firstSVIter != currentchrRegions.end() && std::get<0>(*firstSVIter) < aln.core.pos)
-    {
-        firstSVIter++;
-    }
-
-    if( firstVariantIter == currentChrVariants.end() ){
-        return 0;
-    }
-
-    // position relative to reference
-    int ref_pos = aln.core.pos;
-    // position relative to read
-    int query_pos = 0;
-    // set variant start for current alignment
-    std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
-    // set first SV start for current alignment
-    std::vector<std::tuple<int, int, int> >::iterator currentchrRegionIter = firstSVIter;
-
-    // reading cigar to detect snp on this read
-    int aln_core_n_cigar = int(aln.core.n_cigar);
-    for(int i = 0; i < aln_core_n_cigar ; i++ ){
-        uint32_t *cigar = bam_get_cigar(&aln);
-        int cigar_op = bam_cigar_op(cigar[i]);
-        int length   = bam_cigar_oplen(cigar[i]);
-
-        // iterator next variant
-        while( currentVariantIter != currentChrVariants.end() && (*currentVariantIter).first < ref_pos ){
-            currentVariantIter++;
-        }
-         // iterator next SV
-        while (currentchrRegionIter != currentchrRegions.end() && std::get<0>(*currentchrRegionIter) < ref_pos)
-        {
-            currentchrRegionIter++;
+    for (int j = std::max(cigarIdx - svWindow, 0); j < std::min(cigarIdx + svWindow, n_cigar); j++) {
+        int cigar_op = bam_cigar_op(cigar[j]);
+        int cigar_oplen = bam_cigar_oplen(cigar[j]);
+        if (cigar_op == BAM_CDEL && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < svThreshold) {
+            readSVHapCount[bam_get_qname(&aln)][svHaplotype]++;
+            break;
         }
 
-        int window_size = svWindow;
-        double threshold = svThreshold;
-        // make sure is in the region
-        if (currentchrRegionIter != currentchrRegions.end())
-        {
-            int sv_start = std::get<0>(*currentchrRegionIter);
-            int sv_length = std::get<1>(*currentchrRegionIter);
-            int sv_end = sv_start + std::abs(sv_length);
-            int svHaplotype = std::get<2>(*currentchrRegionIter);
-            double sv_region = sv_end - sv_start + 1;
-
-            for (int j = std::max(i - window_size, 0); j < std::min(i + window_size, aln_core_n_cigar); j++) {
-                int cigar_op = bam_cigar_op(cigar[j]);
-                int cigar_oplen = bam_cigar_oplen(cigar[j]);
-                if (cigar_op == BAM_CDEL && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < threshold)
-                {
-                    readSVHapCount[bam_get_qname(&aln)][svHaplotype]++;
-                    break;
-                }
-
-                if (cigar_op == BAM_CINS && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < threshold)
-                {
-                    readSVHapCount[bam_get_qname(&aln)][svHaplotype]++;
-                    break;
-                }
-            }
+        if (cigar_op == BAM_CINS && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < svThreshold) {
+            readSVHapCount[bam_get_qname(&aln)][svHaplotype]++;
+            break;
         }
+    }
+}
 
-        // CIGAR operators: MIDNSHP=X correspond 012345678
-        // 0: alignment match (can be a sequence match or mismatch)
-        // 7: sequence match
-        // 8: sequence mismatch
-        if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
+void HaplotagProcess::collectMatchOpEvidence(const bam1_t &aln, const std::string &chrName,
+                                             int ref_pos, int query_pos, int length,
+                                             int cigarIdx, int n_cigar, const uint32_t *cigar,
+                                             std::map<int, SnpVariant>::iterator &variantIter,
+                                             std::map<int, int> &variantsHP, std::map<int, int> &countPS,
+                                             int &hp1Count, int &hp2Count)
+{
+    while (variantIter != currentChrVariants.end() && (*variantIter).first < ref_pos + length) {
 
-            while( currentVariantIter != currentChrVariants.end() && (*currentVariantIter).first < ref_pos + length){
+        int refAlleleLen = (*variantIter).second.Ref.length();
+        int altAlleleLen = (*variantIter).second.Alt.length();
+        int offset = (*variantIter).first - ref_pos;
 
-                int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                int offset = (*currentVariantIter).first - ref_pos;
+        if (offset >= 0) {
+            uint8_t *q = bam_get_seq(&aln);
+            char base_chr = seq_nt16_str[bam_seqi(q, query_pos + offset)];
+            std::string base(1, base_chr);
 
-                if( offset < 0){
-                }
-                else{
-                    uint8_t *q = bam_get_seq(&aln);
-                    char base_chr = seq_nt16_str[bam_seqi(q,query_pos + offset)];
-                    std::string base(1, base_chr);
-                    
-                    // currentVariant is SNP
-                    if( refAlleleLen == 1 && altAlleleLen == 1 ){
-                        // Detected that the base of the read is either REF or ALT. 
-                        if( (base == (*currentVariantIter).second.Ref) || (base == (*currentVariantIter).second.Alt) ){
+            // currentVariant is SNP
+            if (refAlleleLen == 1 && altAlleleLen == 1) {
+                // Detected that the base of the read is either REF or ALT.
+                if ((base == (*variantIter).second.Ref) || (base == (*variantIter).second.Alt)) {
 
-                            std::map<int, int>::iterator posPSiter = chrVariantPS[chrName].find((*currentVariantIter).first);
+                    std::map<int, int>::iterator posPSiter = chrVariantPS[chrName].find((*variantIter).first);
 
-                            if( posPSiter == chrVariantPS[chrName].end() ){
-                                std::cerr<< (*currentVariantIter).first << "\t"
-                                         << (*currentVariantIter).second.Ref << "\t"
-                                         << (*currentVariantIter).second.Alt << "\n";
-                                exit(EXIT_SUCCESS);
-                            }
-                            else{
-                                if( base == chrVariantHP1[chrName][(*currentVariantIter).first]){
-                                    hp1Count++;
-                                    variantsHP[(*currentVariantIter).first]=0;
-                                }
-                                if( base == chrVariantHP2[chrName][(*currentVariantIter).first]){
-                                    hp2Count++;
-                                    variantsHP[(*currentVariantIter).first]=1;
-                                }
-                                countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
-                            }
-                            
-                        }
+                    if (posPSiter == chrVariantPS[chrName].end()) {
+                        std::cerr << (*variantIter).first << "\t"
+                                  << (*variantIter).second.Ref << "\t"
+                                  << (*variantIter).second.Alt << "\n";
+                        exit(EXIT_SUCCESS);
                     }
-                    // currentVariant is insertion
-                    else if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
-                        
-                        int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
-                        int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
-                        
-                        if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 1 ) {
-                            // hp1 occur insertion
-                            if( hp1Length != 1 && hp2Length == 1 ){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
-                            // hp2 occur insertion
-                            else if( hp1Length == 1 && hp2Length != 1 ){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
+                    else {
+                        if (base == chrVariantHP1[chrName][(*variantIter).first]) {
+                            hp1Count++;
+                            variantsHP[(*variantIter).first]=0;
                         }
-                        else {
-                            // hp1 occur insertion
-                            if( hp1Length != 1 && hp2Length == 1 ){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
-                            // hp2 occur insertion
-                            else if( hp1Length == 1 && hp2Length != 1 ){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
+                        if (base == chrVariantHP2[chrName][(*variantIter).first]) {
+                            hp2Count++;
+                            variantsHP[(*variantIter).first]=1;
                         }
-                        countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
-                    } 
-                    // currentVariant is deletion
-                    else if( refAlleleLen != 1 && altAlleleLen == 1 && i+1 < aln_core_n_cigar) {
-                        
-                        int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
-                        int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
-                        
-                        if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 2 ) {
-                            // hp1 occur deletion
-                            if( hp1Length != 1 && hp2Length == 1 ){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
-                            // hp2 occur deletion
-                            else if( hp1Length == 1 && hp2Length != 1 ){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
-                        }
-                        else {
-                            // hp2 occur deletion
-                            if( hp1Length != 1 && hp2Length == 1 ){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
-                            // hp1 occur deletion
-                            else if( hp1Length == 1 && hp2Length != 1 ){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
-                        }
-                        countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
-                    } 
-
-                }
-                currentVariantIter++;
-            }
-            query_pos += length;
-            ref_pos += length;
-        }
-            // 1: insertion to the reference
-        else if( cigar_op == 1 ){
-            query_pos += length;
-        }
-            // 2: deletion from the reference
-        else if( cigar_op == 2 ){
-            
-            if(ref_string != ""){
-                int del_len = length;
-                if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
-                    //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
-                        // special case
-                    //}
-                }
-                else if( (*currentVariantIter).first >= ref_pos  && (*currentVariantIter).first < ref_pos + del_len ){
-                    // check variant in homopolymer
-                    if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
-                        
-                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                        
-                        // SNP
-                        if( refAlleleLen == 1 && altAlleleLen == 1){
-                            // get the next match
-                            char base_chr = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
-                            std::string base(1, base_chr);
-
-                            if( base == chrVariantHP1[chrName][(*currentVariantIter).first]){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
-                            if( base == chrVariantHP2[chrName][(*currentVariantIter).first]){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
-                            countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
-                        }
-                        
-                        // the read deletion contain VCF's deletion
-                        else if( refAlleleLen != 1 && altAlleleLen == 1){
-
-                            int hp1Length = chrVariantHP1[chrName][(*currentVariantIter).first].length();
-                            int hp2Length = chrVariantHP2[chrName][(*currentVariantIter).first].length();
-                            // hp1 occur deletion
-                            if( hp1Length != 1 && hp2Length == 1 ){
-                                hp1Count++;
-                                variantsHP[(*currentVariantIter).first]=0;
-                            }
-                            // hp2 occur deletion
-                            else if( hp1Length == 1 && hp2Length != 1 ){
-                                hp2Count++;
-                                variantsHP[(*currentVariantIter).first]=1;
-                            }
-                            countPS[chrVariantPS[chrName][(*currentVariantIter).first]]++;
-                        }
+                        countPS[chrVariantPS[chrName][(*variantIter).first]]++;
                     }
+
                 }
             }
-            ref_pos += length;
+            // currentVariant is insertion
+            else if (refAlleleLen == 1 && altAlleleLen != 1 && cigarIdx + 1 < n_cigar) {
+
+                int hp1Length = chrVariantHP1[chrName][(*variantIter).first].length();
+                int hp2Length = chrVariantHP2[chrName][(*variantIter).first].length();
+                bool readHasIndel = (ref_pos + length - 1 == (*variantIter).first && bam_cigar_op(cigar[cigarIdx+1]) == 1);
+                std::pair<int, int> indelScore = scoreIndelSupport(readHasIndel, hp1Length, hp2Length);
+
+                hp1Count += indelScore.first;
+                hp2Count += indelScore.second;
+                if (indelScore.first > 0)
+                    variantsHP[(*variantIter).first]=0;
+                if (indelScore.second > 0)
+                    variantsHP[(*variantIter).first]=1;
+                countPS[chrVariantPS[chrName][(*variantIter).first]]++;
+            }
+            // currentVariant is deletion
+            else if (refAlleleLen != 1 && altAlleleLen == 1 && cigarIdx + 1 < n_cigar) {
+
+                int hp1Length = chrVariantHP1[chrName][(*variantIter).first].length();
+                int hp2Length = chrVariantHP2[chrName][(*variantIter).first].length();
+                bool readHasIndel = (ref_pos + length - 1 == (*variantIter).first && bam_cigar_op(cigar[cigarIdx+1]) == 2);
+                std::pair<int, int> indelScore = scoreIndelSupport(readHasIndel, hp1Length, hp2Length);
+
+                hp1Count += indelScore.first;
+                hp2Count += indelScore.second;
+                if (indelScore.first > 0)
+                    variantsHP[(*variantIter).first]=0;
+                if (indelScore.second > 0)
+                    variantsHP[(*variantIter).first]=1;
+                countPS[chrVariantPS[chrName][(*variantIter).first]]++;
+            }
+
         }
-            // 3: skipped region from the reference
-        else if( cigar_op == 3 ){
-            ref_pos += length;
-        }
-            // 4: soft clipping (clipped sequences present in SEQ)
-        else if( cigar_op == 4 ){
-            query_pos += length;
-        }
-            // 5: hard clipping (clipped sequences NOT present in SEQ)
-            // 6: padding (silent deletion from padded reference)
-        else if( cigar_op == 5 || cigar_op == 6 ){
-            // do nothing
-        }
-        else{
-            std::cerr<< "alignment find unsupported CIGAR operation from read: " << bam_get_qname(&aln) << "\n";
-            exit(1);
+        variantIter++;
+    }
+}
+
+void HaplotagProcess::collectDeletionOpEvidence(const bam1_t &aln, const std::string &chrName,
+                                                int ref_pos, int query_pos, int length,
+                                                const std::string &ref_string,
+                                                std::map<int, SnpVariant>::iterator &variantIter,
+                                                std::map<int, int> &variantsHP, std::map<int, int> &countPS,
+                                                int &hp1Count, int &hp2Count)
+{
+    if (ref_string == "")
+        return;
+
+    int del_len = length;
+    if (ref_pos + del_len + 1 == (*variantIter).first) {
+        //if( homopolymerLength((*variantIter).first , ref_string) >=3 ){
+            // special case
+        //}
+    }
+    else if ((*variantIter).first >= ref_pos && (*variantIter).first < ref_pos + del_len) {
+        // check variant in homopolymer
+        if (homopolymerLength((*variantIter).first, ref_string) >= 3) {
+
+            int refAlleleLen = (*variantIter).second.Ref.length();
+            int altAlleleLen = (*variantIter).second.Alt.length();
+
+            // SNP
+            if (refAlleleLen == 1 && altAlleleLen == 1) {
+                // get the next match
+                char base_chr = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
+                std::string base(1, base_chr);
+
+                if (base == chrVariantHP1[chrName][(*variantIter).first]) {
+                    hp1Count++;
+                    variantsHP[(*variantIter).first]=0;
+                }
+                if (base == chrVariantHP2[chrName][(*variantIter).first]) {
+                    hp2Count++;
+                    variantsHP[(*variantIter).first]=1;
+                }
+                countPS[chrVariantPS[chrName][(*variantIter).first]]++;
+            }
+
+            // the read deletion contain VCF's deletion
+            else if (refAlleleLen != 1 && altAlleleLen == 1) {
+
+                int hp1Length = chrVariantHP1[chrName][(*variantIter).first].length();
+                int hp2Length = chrVariantHP2[chrName][(*variantIter).first].length();
+                std::pair<int, int> indelScore = scoreIndelSupport(true, hp1Length, hp2Length);
+
+                hp1Count += indelScore.first;
+                hp2Count += indelScore.second;
+                if (indelScore.first > 0)
+                    variantsHP[(*variantIter).first]=0;
+                if (indelScore.second > 0)
+                    variantsHP[(*variantIter).first]=1;
+                countPS[chrVariantPS[chrName][(*variantIter).first]]++;
+            }
         }
     }
+}
 
+int HaplotagProcess::decideHaplotype(int hp1Count, int hp2Count, const std::map<int, int> &countPS,
+                                     double percentageThreshold, int &pqValue)
+{
     double min,max;
-
-    auto readIter = readSVHapCount.find(bam_get_qname(&aln));
-    if( readIter != readSVHapCount.end() ){
-        hp1Count += readSVHapCount[bam_get_qname(&aln)][0];
-        hp2Count += readSVHapCount[bam_get_qname(&aln)][1];
-    }
 
     if(hp1Count > hp2Count){
         min = hp2Count;
@@ -813,54 +766,174 @@ int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, 
     else{
         pqValue=-10*(std::log10((double)min/double(max+min)));
     }
-    
+
     // cross two block
     if( countPS.size() > 1  ){
         hpResult = 0;
     }
 
-    if(tagResult!=NULL){
-        //write tag log file
-        std::string hpResultStr = ((hpResult == 0 )? "." : std::to_string(hpResult) );
-        std::string psResultStr = ".";
+    return hpResult;
+}
 
-        if( hpResultStr != "." ){
-            auto psIter = countPS.begin();
-            psResultStr = std::to_string((*psIter).first);
-        }
+void HaplotagProcess::writeReadLogRow(const bam_hdr_t &bamHdr, const bam1_t &aln,
+                                      int hpResult, int hp1Count, int hp2Count,
+                                      const std::map<int, int> &variantsHP, const std::map<int, int> &countPS,
+                                      int pqValue, std::ofstream *tagResult)
+{
+    if(tagResult==NULL)
+        return;
 
-        (*tagResult)<< bam_get_qname(&aln)              << "\t"
-                    << bamHdr.target_name[aln.core.tid] << "\t"
-                    << aln.core.pos                     << "\t"
-                    << max/(max+min)                    << "\t"
-                    << hpResultStr                      << "\t"
-                    << psResultStr                      << "\t"
-                    << hp1Count+hp2Count                << "\t"
-                    << hp1Count                         << "\t"
-                    << hp2Count                         << "\t"
-                    << pqValue                          << "\t";
-
-
-        // print position and HP
-        for(auto v : variantsHP ){
-            (*tagResult)<< " " << v.first << "," << v.second ;
-        }
-
-        (*tagResult) << "\t";
-
-        // belong PS, number of variant
-        for(auto v : countPS ){
-            (*tagResult)<< " " << v.first << "," << v.second ;
-        }
-
-        (*tagResult)<< "\n";
+    double min,max;
+    if(hp1Count > hp2Count){
+        min = hp2Count;
+        max = hp1Count;
     }
+    else{
+        min = hp1Count;
+        max = hp2Count;
+    }
+
+    //write tag log file
+    std::string hpResultStr = ((hpResult == 0 )? "." : std::to_string(hpResult) );
+    std::string psResultStr = ".";
+
+    if( hpResultStr != "." ){
+        auto psIter = countPS.begin();
+        psResultStr = std::to_string((*psIter).first);
+    }
+
+    (*tagResult)<< bam_get_qname(&aln)              << "\t"
+                << bamHdr.target_name[aln.core.tid] << "\t"
+                << aln.core.pos                     << "\t"
+                << max/(max+min)                    << "\t"
+                << hpResultStr                      << "\t"
+                << psResultStr                      << "\t"
+                << hp1Count+hp2Count                << "\t"
+                << hp1Count                         << "\t"
+                << hp2Count                         << "\t"
+                << pqValue                          << "\t";
+
+
+    // print position and HP
+    for(auto v : variantsHP ){
+        (*tagResult)<< " " << v.first << "," << v.second ;
+    }
+
+    (*tagResult) << "\t";
+
+    // belong PS, number of variant
+    for(auto v : countPS ){
+        (*tagResult)<< " " << v.first << "," << v.second ;
+    }
+
+    (*tagResult)<< "\n";
+}
+
+int HaplotagProcess::judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue, const std::string &ref_string, int svWindow, double svThreshold){
+
+    int hp1Count = 0;
+    int hp2Count = 0;
+    //record variants on this read
+    std::map<int,int> variantsHP;
+    std::map<int,int> countPS;
+
+    // Skip variants that are to the left of this read
+    while( firstVariantIter != currentChrVariants.end() && (*firstVariantIter).first < aln.core.pos ){
+        firstVariantIter++;
+    }
+
+    // Skip SVs that are to the left of this read
+    while (firstSVIter != currentchrRegions.end() && std::get<0>(*firstSVIter) < aln.core.pos)
+    {
+        firstSVIter++;
+    }
+
+    if( firstVariantIter == currentChrVariants.end() ){
+        return 0;
+    }
+
+    // position relative to reference
+    int ref_pos = aln.core.pos;
+    // position relative to read
+    int query_pos = 0;
+    // set variant start for current alignment
+    std::map<int, SnpVariant>::iterator currentVariantIter = firstVariantIter;
+    // set first SV start for current alignment
+    std::vector<std::tuple<int, int, int> >::iterator currentchrRegionIter = firstSVIter;
+
+    // reading cigar to detect snp on this read
+    int aln_core_n_cigar = int(aln.core.n_cigar);
+    for(int i = 0; i < aln_core_n_cigar ; i++ ){
+        uint32_t *cigar = bam_get_cigar(&aln);
+        int cigar_op = bam_cigar_op(cigar[i]);
+        int length   = bam_cigar_oplen(cigar[i]);
+
+        // iterator next variant
+        while( currentVariantIter != currentChrVariants.end() && (*currentVariantIter).first < ref_pos ){
+            currentVariantIter++;
+        }
+         // iterator next SV
+        while (currentchrRegionIter != currentchrRegions.end() && std::get<0>(*currentchrRegionIter) < ref_pos)
+        {
+            currentchrRegionIter++;
+        }
+
+        collectSVWindowEvidence(aln, i, aln_core_n_cigar, cigar, currentchrRegionIter, svWindow, svThreshold);
+
+        // CIGAR operators: MIDNSHP=X correspond 012345678
+        // 0: alignment match (can be a sequence match or mismatch)
+        // 7: sequence match
+        // 8: sequence mismatch
+        if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
+            collectMatchOpEvidence(aln, chrName, ref_pos, query_pos, length, i, aln_core_n_cigar, cigar,
+                                   currentVariantIter, variantsHP, countPS, hp1Count, hp2Count);
+            query_pos += length;
+            ref_pos += length;
+        }
+            // 1: insertion to the reference
+        else if( cigar_op == 1 ){
+            query_pos += length;
+        }
+            // 2: deletion from the reference
+        else if( cigar_op == 2 ){
+            collectDeletionOpEvidence(aln, chrName, ref_pos, query_pos, length, ref_string,
+                                      currentVariantIter, variantsHP, countPS, hp1Count, hp2Count);
+            ref_pos += length;
+        }
+            // 3: skipped region from the reference
+        else if( cigar_op == 3 ){
+            ref_pos += length;
+        }
+            // 4: soft clipping (clipped sequences present in SEQ)
+        else if( cigar_op == 4 ){
+            query_pos += length;
+        }
+            // 5: hard clipping (clipped sequences NOT present in SEQ)
+            // 6: padding (silent deletion from padded reference)
+        else if( cigar_op == 5 || cigar_op == 6 ){
+            // do nothing
+        }
+        else{
+            std::cerr<< "alignment find unsupported CIGAR operation from read: " << bam_get_qname(&aln) << "\n";
+            exit(1);
+        }
+    }
+
+    auto readIter = readSVHapCount.find(bam_get_qname(&aln));
+    if( readIter != readSVHapCount.end() ){
+        hp1Count += readSVHapCount[bam_get_qname(&aln)][0];
+        hp2Count += readSVHapCount[bam_get_qname(&aln)][1];
+    }
+
+    int hpResult = decideHaplotype(hp1Count, hp2Count, countPS, percentageThreshold, pqValue);
+
+    writeReadLogRow(bamHdr, aln, hpResult, hp1Count, hp2Count, variantsHP, countPS, pqValue, tagResult);
 
     return hpResult;
 }
 
 HaplotagProcess::HaplotagProcess(HaplotagParameters params):
-totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),totalTagCount(0),totalUnTagCount(0),processBegin(time(NULL)),integerPS(false)
+totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),totalTagCount(0),totalUnTagCount(0),processBegin(time(NULL)),integerPS(false),parseSnpFile(false),parseSVFile(false),parseMODFile(false)
 {
     std::cerr<< "phased SNP file    : " << params.snpFile             << "\n";
     std::cerr<< "phased SV file     : " << params.svFile              << "\n";
@@ -897,9 +970,9 @@ totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),total
         parseSVFile = true;
         variantParser(params.svFile);
         parseSVFile = false;
-        std::cerr<< difftime(time(NULL), begin) << "s\n";    
+        std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
-    
+
     // load MOD vcf file
     if(params.modFile!=""){
         begin = time(NULL);
@@ -907,7 +980,7 @@ totalAlignment(0),totalSupplementary(0),totalSecondary(0),totalUnmapped(0),total
         parseMODFile = true;
         variantParser(params.modFile);
         parseMODFile = false;
-        std::cerr<< difftime(time(NULL), begin) << "s\n";    
+        std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
 
     // tag read
@@ -929,4 +1002,3 @@ HaplotagProcess::~HaplotagProcess(){
     std::cerr<< "total tag alignment: " << totalTagCount     << "\n";
     std::cerr<< "total untagged:      " << totalUnTagCount   << "\n";
 };
-

--- a/HaplotagProcess.h
+++ b/HaplotagProcess.h
@@ -35,14 +35,26 @@ class HaplotagProcess
     void compressParser(std::string &variantFile);
     void unCompressParser(std::string &variantFile);
     void parserProcess(std::string &input);
+    void parseHeaderLine(const std::string &line);
+    void parseRecordLine(const std::string &line);
+    void processSnpRecord(const std::vector<std::string> &fields, int pos, int haploDir, const std::string &psValue);
+    void processSvRecord(const std::vector<std::string> &fields, int haploDir);
+    void processModRecord(const std::vector<std::string> &fields, int haploDir);
     
+    std::vector<int> collectLastVariantPos() const;
+    std::ofstream* initLogFile(const HaplotagParameters &params);
+    void resolveRegionScope(const HaplotagParameters &params);
+    void tagChromosome(const std::string &chr, const HaplotagParameters &params,
+                       samFile *in, samFile *out, bam_hdr_t *bamHdr, hts_idx_t *idx,
+                       bam1_t *aln, const std::string &chr_reference, std::ofstream *tagResult);
+    void writeUnmappedTail(samFile *in, samFile *out, bam_hdr_t *bamHdr, hts_idx_t *idx);
     void tagRead(HaplotagParameters &params);
     
     std::vector<std::string> chrVec;
     std::map<std::string, int> chrLength;
     
     // chr, variant position (0-base), allele haplotype
-    std::map<std::string, std::map<int, RefAlt> > chrVariant;
+    std::map<std::string, std::map<int, SnpVariant> > chrVariant;
     // chr, variant position (0-base), phased set
     std::map<std::string, int > psIndex;
     std::map<std::string, std::map<int, int> > chrVariantPS;
@@ -50,8 +62,8 @@ class HaplotagProcess
     std::map<std::string, std::map<int, std::string> > chrVariantHP1;
     std::map<std::string, std::map<int, std::string> > chrVariantHP2;
 
-    std::map<int, RefAlt> currentChrVariants;
-    std::map<int, RefAlt>::iterator firstVariantIter;
+    std::map<int, SnpVariant> currentChrVariants;
+    std::map<int, SnpVariant>::iterator firstVariantIter;
     // The number of SVs occurring on different haplotypes in a read
     std::map<std::string, std::map<int, int> > readSVHapCount;
 
@@ -61,7 +73,29 @@ class HaplotagProcess
     std::vector<std::tuple<int, int, int> >::iterator firstSVIter;
 
     void initFlag(bam1_t *aln, std::string flag);
-    
+
+    void collectSVWindowEvidence(const bam1_t &aln, int cigarIdx, int n_cigar,
+                                 const uint32_t *cigar,
+                                 std::vector<std::tuple<int, int, int> >::iterator svIter,
+                                 int svWindow, double svThreshold);
+    void collectMatchOpEvidence(const bam1_t &aln, const std::string &chrName,
+                                int ref_pos, int query_pos, int length,
+                                int cigarIdx, int n_cigar, const uint32_t *cigar,
+                                std::map<int, SnpVariant>::iterator &variantIter,
+                                std::map<int, int> &variantsHP, std::map<int, int> &countPS,
+                                int &hp1Count, int &hp2Count);
+    void collectDeletionOpEvidence(const bam1_t &aln, const std::string &chrName,
+                                   int ref_pos, int query_pos, int length,
+                                   const std::string &ref_string,
+                                   std::map<int, SnpVariant>::iterator &variantIter,
+                                   std::map<int, int> &variantsHP, std::map<int, int> &countPS,
+                                   int &hp1Count, int &hp2Count);
+    int decideHaplotype(int hp1Count, int hp2Count, const std::map<int, int> &countPS,
+                        double percentageThreshold, int &pqValue);
+    void writeReadLogRow(const bam_hdr_t &bamHdr, const bam1_t &aln,
+                         int hpResult, int hp1Count, int hp2Count,
+                         const std::map<int, int> &variantsHP, const std::map<int, int> &countPS,
+                         int pqValue, std::ofstream *tagResult);
     int judgeHaplotype(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::string chrName, double percentageThreshold, std::ofstream *tagResult, int &pqValue, const std::string &ref_string, int svWindow, double svThreshold);
     
     int totalAlignment;
@@ -76,7 +110,6 @@ class HaplotagProcess
     bool parseSnpFile;
     bool parseSVFile;
     bool parseMODFile;
-    
     public:
         HaplotagProcess(HaplotagParameters params);
         ~HaplotagProcess();

--- a/ModCallParsingBam.cpp
+++ b/ModCallParsingBam.cpp
@@ -2,1466 +2,1359 @@
 #include "PhasingGraph.h"
 #include "Util.h"
 
-#include <cmath>
-#include <iostream>
-#include <string.h>
-#include <sstream>
-#include <fstream>
-#include <typeinfo>
-#include <algorithm>
-#include "htslib/thread_pool.h"
 #include "htslib/sam.h"
+#include "htslib/thread_pool.h"
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string.h>
+#include <typeinfo>
 
-MethFastaParser::MethFastaParser(std::string fastaFile, std::vector<ReferenceChromosome> &chrInfo){
-    if(fastaFile==""){
-        return;
-    }
-    
-    faidx_t *fai = NULL;
-    fai = fai_load(fastaFile.c_str());
-    int fai_nseq = faidx_nseq(fai);
-    const char *seqname;
-    int seqlen = 0;
-    for(int i=0;i<fai_nseq;i++){
-        int ref_len = 0;
-        seqname = faidx_iseq(fai, i);
-        seqlen = faidx_seq_len(fai, seqname);
-        chrInfo.emplace_back(seqname, faidx_fetch_seq(fai , seqname , 0 ,seqlen+1 , &ref_len), seqlen);
-    }
+MethFastaParser::MethFastaParser(std::string fastaFile,
+                                 std::vector<ReferenceChromosome> &chrInfo) {
+  if (fastaFile == "") {
+    return;
+  }
+
+  faidx_t *fai = fai_load(fastaFile.c_str());
+  int fai_nseq = faidx_nseq(fai);
+  const char *seqname;
+  int seqlen = 0;
+  for (int i = 0; i < fai_nseq; i++) {
+    int ref_len = 0;
+    seqname = faidx_iseq(fai, i);
+    seqlen = faidx_seq_len(fai, seqname);
+    char *seq = faidx_fetch_seq(fai, seqname, 0, seqlen + 1, &ref_len);
+    chrInfo.emplace_back(seqname, seq, seqlen);
+    free(seq);
+  }
+  fai_destroy(fai);
 }
 
-MethFastaParser::~MethFastaParser(){
+MethFastaParser::~MethFastaParser() {}
+
+MethBamParser::MethBamParser(std::string inputChrName,
+                             ModCallParameters &in_params,
+                             MethSnpParser &snpMap, std::string &ref_string)
+    : chrName(inputChrName) {
+  params = &in_params;
+  refString = &ref_string;
+  refstartpos = 0;
+  chrMethMap = new std::map<int, MethPosInfo>;
+  readStartEndMap = new std::map<int, std::pair<int, int>>;
+
+  currentVariants = new std::map<int, SnpVariant>;
+
+  if (snpMap.hasValidSnpData()) {
+    (*currentVariants) = snpMap.getVariants_markindel(chrName, ref_string);
+  }
+
+  firstVariantIter = currentVariants->begin();
 }
 
-MethBamParser::MethBamParser(std::string inputChrName, ModCallParameters &in_params, MethSnpParser &snpMap, std::string &ref_string):chrName(inputChrName){
-    params=&in_params;
-    refString = &ref_string;
-    refstartpos = 0;    
-    chrMethMap = new std::map<int , MethPosInfo>;
-    readStartEndMap = new std::map<int, std::pair<int,int>>; 
-
-    currentVariants = new std::map<int, RefAlt>;
-
-    if(snpMap.hasValidSnpData()){
-        (*currentVariants) = snpMap.getVariants_markindel(chrName, ref_string);
-    }
-
-    firstVariantIter = currentVariants->begin();
+MethBamParser::~MethBamParser() {
+  delete chrMethMap;
+  delete readStartEndMap;
+  delete currentVariants;
 }
 
-MethBamParser::~MethBamParser(){
-    delete chrMethMap;
-    delete readStartEndMap;
-    delete currentVariants;
+bool MethBamParser::isValidAlignment(const bam1_t *aln) const {
+  // Intentionally different from phase/haplotag filters: fixed qual>=1;
+  // supplementary (0x800) alignments are excluded.
+  int flag = aln->core.flag;
+  return aln->core.qual >= 1
+         && (flag & 0x4) == 0   // not unmapped
+         && (flag & 0x100) == 0 // not secondary
+         && (flag & 0x400) == 0 // not duplicate
+         && (flag & 0x800) == 0;
 }
 
-void MethBamParser::detectMeth(std::string chrName, int lastSNPPos, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec){
-    // record SNP start iter
-    std::map<int, RefAlt>::iterator tmpFirstVariantIter = firstVariantIter;
-    for( auto bamFile: params->bamFileVec ){
-        firstVariantIter = tmpFirstVariantIter;
-        // open cram file
-        samFile *fp_in = hts_open(bamFile.c_str(),"r");
-        // set reference
-        hts_set_fai_filename(fp_in, params->fastaFile.c_str());        
-        // read header
-        bam_hdr_t *bamHdr = sam_hdr_read(fp_in); 
-        // initialize an alignment
-        bam1_t *aln = bam_init1(); 
-        hts_idx_t *idx = NULL;
-        
-        if ((idx = sam_index_load(fp_in, bamFile.c_str())) == 0) {
-            std::cout<<"ERROR: Cannot open index for bam file\n";
-            exit(1);
+bool MethBamParser::extractSnpAllele(
+    std::map<int, SnpVariant>::iterator &currentVariantIter, int ref_pos,
+    int length, int querypos, int cigaridx, int aln_core_n_cigar,
+    const uint32_t *cigar, const bam1_t &aln, ReadVariant *tmpReadResult) {
+  while (currentVariantIter != currentVariants->end() &&
+         currentVariantIter->first < ref_pos + length) {
+    int variantPos = currentVariantIter->first;
+    if (variantPos >= ref_pos) {
+      int refAlleleLen = currentVariantIter->second.Ref.length();
+      int altAlleleLen = currentVariantIter->second.Alt.length();
+      int offset = variantPos - ref_pos;
+      int base_q = 0;
+      int allele = -1;
+
+      if (querypos + offset + 1 > int(aln.core.l_qseq)) {
+        return false;
+      }
+
+      if (refAlleleLen == 1 && altAlleleLen == 1) {
+        char base =
+            seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos + offset)];
+        if (base == currentVariantIter->second.Ref[0])
+          allele = 0;
+        else if (base == currentVariantIter->second.Alt[0])
+          allele = 1;
+
+        base_q = bam_get_qual(&aln)[querypos + offset];
+      }
+
+      if (refAlleleLen == 1 && altAlleleLen != 1 &&
+          cigaridx + 1 < aln_core_n_cigar) {
+        if (ref_pos + length - 1 == variantPos &&
+            bam_cigar_op(cigar[cigaridx + 1]) == 1) {
+          allele = 1;
+        } else {
+          allele = 0;
         }
-        
-        std::string range = chrName + ":1-" + std::to_string(lastSNPPos);
-        hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
+        base_q = -4;
 
-        
-        int result;
-        hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
-
-        while ((result = sam_itr_next(fp_in, iter, aln)) >= 0) { 
-            int flag = aln->core.flag;
-
-            if (  aln->core.qual < 1  // mapping quality
-                 || (flag & 0x4)   != 0  // read unmapped
-                 || (flag & 0x100) != 0  // secondary alignment. repeat. 
-                                         // A secondary alignment occurs when a given read could align reasonably well to more than one place.
-                 || (flag & 0x400) != 0  // duplicate 
-                 || (flag & 0x800) != 0  // supplementary alignment
-                                         // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
-                 ){
-                continue;
-            }
-            parse_CIGAR(*bamHdr,*aln, readVariantVec);
+        if (currentVariantIter->second.is_danger) {
+          base_q = -5;
         }
+      }
 
-        hts_itr_destroy(iter);
-        hts_idx_destroy(idx);
-        bam_hdr_destroy(bamHdr);
-        bam_destroy1(aln);
-        sam_close(fp_in);
+      if (refAlleleLen != 1 && altAlleleLen == 1 &&
+          cigaridx + 1 < aln_core_n_cigar) {
+        if (ref_pos + length - 1 == variantPos &&
+            bam_cigar_op(cigar[cigaridx + 1]) == 2) {
+          allele = 1;
+        } else {
+          allele = 0;
+        }
+        base_q = -4;
+
+        if (currentVariantIter->second.is_danger) {
+          base_q = -5;
+        }
+      }
+
+      if (allele != -1) {
+        tmpReadResult->variantVec.emplace_back(variantPos, allele, base_q,
+                                               VariantType::SNP);
+        (*chrMethMap)[variantPos].variantType = VariantType::SNP;
+      }
     }
+    currentVariantIter++;
+  }
+  return true;
 }
 
-void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec){
-    // see detail https://github.com/samtools/htslib/blob/develop/sam_mods.c
-    
-    // hts_base_mod_state can parse MM, ML and MN tags
-    hts_base_mod_state *mod_state = hts_base_mod_state_alloc();
-    if( bam_parse_basemod( &aln, mod_state) < 0 ){
-        hts_base_mod_state_free(mod_state);
-        return;
+void MethBamParser::classifyMethylationBase(
+    int &n, int &pos, hts_base_mod *mods, int querypos, int length,
+    int refpos, const bam1_t &aln, ReadVariant *tmpReadResult,
+    hts_base_mod_state *mod_state) {
+  while (true) {
+    if (pos > (querypos + length)) {
+      break;
     }
-    /* 
-    // see detail https://github.com/samtools/htslib/issues/1550
-    
-    // Assuming there are a total of 10 types of modifications.
-    n_mods = 10;
-    hts_base_mod allmod[n_mods];
-    while ((n = bam_next_basemod(&aln, mod_state, allmod, n_mods, &pos)) > 0) {
-        // Report 'n'th mod at sequence position 'pos'
-        for (j = 0; j < n && j < n_mods; j++) {
-            //5mC  code:m ascii:109
-            //5hmC code:h ascii:104
-            //see sam tags pdf
-            if (allmod[j].modified_base == 109) {
-                queryMethVec.emplace_back(pos, allmod[j].qual);
-            }
-        }
-    }*/
- 
-    ReadVariant *tmpReadResult = new ReadVariant();
-    (*tmpReadResult).read_name = bam_get_qname(&aln);
-    (*tmpReadResult).source_id = bamHdr.target_name[aln.core.tid];
-    (*tmpReadResult).reference_start = aln.core.pos;
-    (*tmpReadResult).is_reverse = bam_is_rev(&aln);
-    
-    int refstart = aln.core.pos;
-    // forward strand is checked from head to tail
-    // reverse strand is checked from tail to head
-    int refpos = (bam_is_rev(&aln) ? refstart + 1 : refstart);
-    int ref_pos = aln.core.pos;
-    //auto qmethiter = (align.is_reverse ? align.queryMethVec.end()-1 : align.queryMethVec.begin() );
-    int querypos = 0;
-    int aln_core_n_cigar = aln.core.n_cigar;
-    uint32_t *cigar = bam_get_cigar(&aln);
-    
-    hts_base_mod mods[5];
-    int pos;
-    // bam_next_basemod can iterate over this cached state.
-    int n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-    if( n <= 0 ){ 
-        hts_base_mod_state_free(mod_state);
-        delete tmpReadResult;
-        return;
+    if (n <= 0) {
+      break;
     }
 
-    while( firstVariantIter != currentVariants->end() && (*firstVariantIter).first < ref_pos ){
-        firstVariantIter++;
+    int methrpos;
+    if (bam_is_rev(&aln)) {
+      methrpos = pos - querypos + refpos - 1;
+    } else {
+      methrpos = pos - querypos + refpos;
     }
-    // set variant start for current alignment
-    std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
-    
-    //Parse CIGAR 
-    for(int cigaridx = 0; cigaridx < int(aln.core.n_cigar) ; cigaridx++){
 
-        int cigar_op = bam_cigar_op(cigar[cigaridx]);
-        int length = bam_cigar_oplen(cigar[cigaridx]);
-        // get the first variant detected by the alignment.
-        /*while( currentVariantIter != currentVariants->end() && variantPos < ref_pos ){
-            currentVariantIter++;
-            variantPos = (*currentVariantIter).first;
-        }*/
-        //while((currentVariantIter != currentVariants->end() && variantPos < ref_pos + length)){
-            if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
-                while(currentVariantIter != currentVariants->end() && currentVariantIter->first < ref_pos + length){
-                    int variantPos = currentVariantIter->first;
-                    if(variantPos >= ref_pos){
-                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                        int offset = variantPos - ref_pos;
-                        int base_q = 0;
-                        int allele = -1;
-
-                        // The position of the variant exceeds the length of the read.
-                        if( querypos + offset + 1 > int(aln.core.l_qseq) ){
-                            return;
-                        }
-
-                        // SNP
-                        if( refAlleleLen == 1 && altAlleleLen == 1){
-                            char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos + offset)];
-                            if(base == (*currentVariantIter).second.Ref[0])
-                                allele = 0;
-                            else if(base == (*currentVariantIter).second.Alt[0])
-                                allele = 1;
-
-                            base_q = bam_get_qual(&aln)[querypos + offset];
-                        } 
-                
-                        // insertion
-                        //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
-                        if( refAlleleLen == 1 && altAlleleLen != 1 && cigaridx+1 < aln_core_n_cigar){
-                    
-                            // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
-                    
-                            // uint8_t *qstring = bam_get_seq(aln); 
-                            // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
-                            // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
-
-                            if ( ref_pos + length - 1 == variantPos && bam_cigar_op(cigar[cigaridx+1]) == 1 ) {
-                                allele = 1 ;
-                            }
-                            else {
-                                allele = 0 ;
-                            }
-                            // using this quality to identify indel
-                            base_q = -4;
-
-                            // using this quality to identify danger indel
-                            if ( (*currentVariantIter).second.is_danger ) {
-                                base_q = -5 ;
-                            }
-                        } 
-                
-                        // deletion
-                        //if( refAlleleLen != 1 && altAlleleLen == 1 && align.op[i+1] == 2 && i+1 < align.cigar_len){
-                        if( refAlleleLen != 1 && altAlleleLen == 1 && cigaridx+1 < aln_core_n_cigar) {
-
-                            if ( ref_pos + length - 1 == variantPos && bam_cigar_op(cigar[cigaridx+1]) == 2 ) {
-                                allele = 1 ;
-                            }
-                            else {
-                                allele = 0 ;
-                            }
-                            // using this quality to identify indel
-                            base_q = -4;
-
-                            // using this quality to identify danger indel
-                            if ( (*currentVariantIter).second.is_danger ) {
-                                base_q = -5 ;
-                            }
-                        } 
-                
-                        if( allele != -1){
-                            // record snp result
-                            (*tmpReadResult).variantVec.emplace_back(variantPos, allele, base_q, VariantType::SNP); 
-                            (*chrMethMap)[variantPos].variantType = VariantType::SNP;                      
-                        }
-                    }
-                    currentVariantIter++;
-                }
-            }
-            //else break;
-        //}
-
-        // CIGAR operators: MIDNSHP=X correspond 012345678
-        // 0: alignment match (can be a sequence match or mismatch)
-        // 7: sequence match
-        // 8: sequence mismatch
-      
-        if(cigar_op == 0 || cigar_op == 7 || cigar_op == 8){
-            while(true){
-                if( pos > (querypos+length) ){
-                    break;
-                }
-                if( n <= 0 ){
-                    break;
-                }
-                int methrpos;
-                if(bam_is_rev(&aln)){
-                    methrpos = pos - querypos + refpos - 1;
-                    
-                }
-                else{
-                    methrpos = pos - querypos + refpos;
-                }
-
-                if( int((*refString).length()) < methrpos ){
-                    break;
-                }
-
-                for (int j = 0; j < n && j < 5; j++) {
-                    auto it = chrMethMap->find(methrpos);
-                    if (mods[j].modified_base == 109 && pos <= (querypos+length) && (it == chrMethMap->end() || it->second.variantType == VariantType::MOD)){
-                        //modification
-                        if( mods[j].qual >= params->modThreshold*255){
-                            (*chrMethMap)[methrpos].methreadcnt++;
-                            (*chrMethMap)[methrpos].variantType = VariantType::MOD;
-                            //strand - is 1, strand + is 0
-                            (*chrMethMap)[methrpos].strand = (bam_is_rev(&aln) ? 1 : 0);
-                            (*chrMethMap)[methrpos].modReadVec.emplace_back(bam_get_qname(&aln));
-                            (*tmpReadResult).variantVec.emplace_back(methrpos, 0, 60, VariantType::MOD);
-                        }
-                        //non-modification (not include no detected)
-                        else if( mods[j].qual <= params->unModThreshold*255 ){ 
-                            (*chrMethMap)[methrpos].canonreadcnt++;
-                            (*chrMethMap)[methrpos].variantType = VariantType::MOD;
-                            (*chrMethMap)[methrpos].nonModReadVec.emplace_back(bam_get_qname(&aln));
-                            (*tmpReadResult).variantVec.emplace_back(methrpos, 1, 60, VariantType::MOD);
-                        }
-                        else{
-                            (*chrMethMap)[methrpos].noisereadcnt++;
-                            (*chrMethMap)[methrpos].variantType = VariantType::MOD;
-                        }
-                    }
-                }
-                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-            }
-            querypos += length;
-            refpos += length;
-            ref_pos += length;
-        }
-        // 1: insertion to the reference
-        else if(cigar_op == 1){ 
-            while(n>0 && pos <= (querypos+length)){
-                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-            }
-            querypos += length;   
-        }
-        // 2: deletion from the reference
-        else if(cigar_op == 2){
-            if(*refString != ""){
-                if(currentVariantIter == currentVariants->end()) {
-                    refpos += length;
-                    ref_pos += length;
-                    continue;
-                }
-
-                int del_len = length;
-                if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
-                    //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
-                        // special case
-                    //}
-                }
-                else if( (*currentVariantIter).first >= ref_pos  && (*currentVariantIter).first < ref_pos + del_len ){
-                    // check snp in homopolymer
-                    if( homopolymerLength((*currentVariantIter).first , *refString) >=3 ){
-                        
-                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                        int base_q = 0;  
-                        
-                        if( querypos + 1 > aln.core.l_qseq ){
-                            hts_base_mod_state_free(mod_state);
-                            delete tmpReadResult;
-                            return;
-                        }
-
-                        int allele = -1;
-                        // SNP
-                        if( refAlleleLen == 1 && altAlleleLen == 1){
-                            // get the next match
-                            char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos)];
-                            if( base == (*currentVariantIter).second.Ref[0] ){
-                                allele = 0;
-                            }
-                            else if( base == (*currentVariantIter).second.Alt[0] ){
-                                allele = 1;
-                            }
-                            base_q = bam_get_qual(&aln)[querypos];
-                        }
-                        // the read deletion contain VCF's deletion
-                        else if( refAlleleLen != 1 && altAlleleLen == 1 ){
-
-                            if( refAlleleLen != 1 && altAlleleLen == 1){
-                                //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
-                                //std::string refSeq = (*currentVariantIter).second.Ref;
-                                //std::string altSeq = (*currentVariantIter).second.Alt;
-
-                                allele = 1;
-                                // using this quality to identify indel
-                                base_q = -4;
-                            }
-                            else if ( allele == -1 ) {
-                                allele = 0;
-                                // using this quality to identify indel
-                                base_q = -4;
-                            }
-                            
-                        }
-                        
-                        if(allele != -1){
-                            (*tmpReadResult).variantVec.emplace_back((*currentVariantIter).first, allele, base_q, VariantType::SNP);
-                            (*chrMethMap)[(*currentVariantIter).first].variantType = VariantType::SNP;
-                            currentVariantIter++;
-                        }
-
-                    }
-                }
-            }
-            refpos += length;
-            ref_pos += length;
-        }
-        // 3: skipped region from the reference
-        else if(cigar_op == 3){
-            refpos += length;
-            ref_pos += length;
-        }
-        // 4: soft clipping (clipped sequences present in SEQ)
-        else if(cigar_op == 4){
-            while(n>0 && pos <= (querypos+length)){
-                n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
-            }
-            querypos += length;
-        }
-        // 5: hard clipping (clipped sequences NOT present in SEQ)
-        // 6: padding (silent deletion from padded reference)
-        else if(cigar_op == 5 || cigar_op == 6){
-            //do nothing
-            refpos += length;
-        }
+    if (int((*refString).length()) < methrpos) {
+      break;
     }
-    
+
+    for (int j = 0; j < n && j < 5; j++) {
+      auto it = chrMethMap->find(methrpos);
+      if (mods[j].modified_base == 109 && pos <= (querypos + length) &&
+          (it == chrMethMap->end() ||
+           it->second.variantType == VariantType::MOD)) {
+        if (mods[j].qual >= params->modThreshold * 255) {
+          (*chrMethMap)[methrpos].methreadcnt++;
+          (*chrMethMap)[methrpos].variantType = VariantType::MOD;
+          (*chrMethMap)[methrpos].strand = (bam_is_rev(&aln) ? 1 : 0);
+          (*chrMethMap)[methrpos].modReadVec.emplace_back(bam_get_qname(&aln));
+          tmpReadResult->variantVec.emplace_back(methrpos, 0, 60,
+                                                 VariantType::MOD);
+        } else if (mods[j].qual <= params->unModThreshold * 255) {
+          (*chrMethMap)[methrpos].canonreadcnt++;
+          (*chrMethMap)[methrpos].variantType = VariantType::MOD;
+          (*chrMethMap)[methrpos].nonModReadVec.emplace_back(
+              bam_get_qname(&aln));
+          tmpReadResult->variantVec.emplace_back(methrpos, 1, 60,
+                                                 VariantType::MOD);
+        } else {
+          (*chrMethMap)[methrpos].noisereadcnt++;
+          (*chrMethMap)[methrpos].variantType = VariantType::MOD;
+        }
+      }
+    }
+    n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+  }
+}
+
+bool MethBamParser::handleDeletionInHomopolymer(
+    std::map<int, SnpVariant>::iterator &currentVariantIter, int ref_pos,
+    int length, int querypos, const bam1_t &aln,
+    hts_base_mod_state *mod_state, ReadVariant *tmpReadResult) {
+  int del_len = length;
+  if (ref_pos + del_len + 1 == currentVariantIter->first) {
+    return true;
+  }
+
+  if (currentVariantIter->first < ref_pos ||
+      currentVariantIter->first >= ref_pos + del_len) {
+    return true;
+  }
+
+  if (homopolymerLength(currentVariantIter->first, *refString) < 3) {
+    return true;
+  }
+
+  int refAlleleLen = currentVariantIter->second.Ref.length();
+  int altAlleleLen = currentVariantIter->second.Alt.length();
+  int base_q = 0;
+
+  if (querypos + 1 > aln.core.l_qseq) {
     hts_base_mod_state_free(mod_state);
-    
-    int refend = (bam_is_rev(&aln) ? refpos : refpos + 1);
+    return false;
+  }
 
-    if(bam_is_rev(&aln)){
-        (*readStartEndMap)[refstart+1].second += 1;
-        (*readStartEndMap)[refend].second -= 1;
+  int allele = -1;
+  if (refAlleleLen == 1 && altAlleleLen == 1) {
+    char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), querypos)];
+    if (base == currentVariantIter->second.Ref[0]) {
+      allele = 0;
+    } else if (base == currentVariantIter->second.Alt[0]) {
+      allele = 1;
     }
-    else{
-        (*readStartEndMap)[refstart+1].first += 1;
-        (*readStartEndMap)[refend].first -= 1;
+    base_q = bam_get_qual(&aln)[querypos];
+  } else if (refAlleleLen != 1 && altAlleleLen == 1) {
+    allele = 1;
+    base_q = -4;
+  }
+
+  if (allele != -1) {
+    tmpReadResult->variantVec.emplace_back(currentVariantIter->first, allele,
+                                           base_q, VariantType::SNP);
+    (*chrMethMap)[currentVariantIter->first].variantType = VariantType::SNP;
+    currentVariantIter++;
+  }
+
+  return true;
+}
+
+void MethBamParser::updateDepthBoundary(int refstart, int refpos,
+                                        bool is_reverse) {
+  int refend = (is_reverse ? refpos : refpos + 1);
+
+  if (is_reverse) {
+    (*readStartEndMap)[refstart + 1].second += 1;
+    (*readStartEndMap)[refend].second -= 1;
+  } else {
+    (*readStartEndMap)[refstart + 1].first += 1;
+    (*readStartEndMap)[refend].first -= 1;
+  }
+}
+
+void MethBamParser::detectMeth(std::string chrName, int lastSNPPos,
+                               htsThreadPool &threadPool,
+                               std::vector<ReadVariant> &readVariantVec) {
+  // record SNP start iter
+  std::map<int, SnpVariant>::iterator tmpFirstVariantIter = firstVariantIter;
+  for (auto bamFile : params->bamFileVec) {
+    firstVariantIter = tmpFirstVariantIter;
+    samFile *fp_in = hts_open(bamFile.c_str(), "r");
+    hts_set_fai_filename(fp_in, params->fastaFile.c_str());
+    bam_hdr_t *bamHdr = sam_hdr_read(fp_in);
+    bam1_t *aln = bam_init1();
+    hts_idx_t *idx = sam_index_load(fp_in, bamFile.c_str());
+
+    if (idx == nullptr) {
+      std::cout << "ERROR: Cannot open index for bam file\n";
+      exit(1);
     }
-    
-    if( (*tmpReadResult).variantVec.size() > 0 ){
-        (*tmpReadResult).sort();
-        readVariantVec.emplace_back((*tmpReadResult));
+
+    std::string range = chrName + ":1-" + std::to_string(lastSNPPos);
+    hts_itr_t *iter = sam_itr_querys(idx, bamHdr, range.c_str());
+
+    hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
+
+    while (sam_itr_next(fp_in, iter, aln) >= 0) {
+      if (!isValidAlignment(aln)) {
+        continue;
+      }
+      parse_CIGAR(*bamHdr, *aln, readVariantVec);
     }
+
+    hts_itr_destroy(iter);
+    hts_idx_destroy(idx);
+    bam_hdr_destroy(bamHdr);
+    bam_destroy1(aln);
+    sam_close(fp_in);
+  }
+}
+
+void MethBamParser::parse_CIGAR(const bam_hdr_t &bamHdr, const bam1_t &aln,
+                                std::vector<ReadVariant> &readVariantVec) {
+  // see detail https://github.com/samtools/htslib/blob/develop/sam_mods.c
+
+  // hts_base_mod_state can parse MM, ML and MN tags
+  hts_base_mod_state *mod_state = hts_base_mod_state_alloc();
+  if (bam_parse_basemod(&aln, mod_state) < 0) {
+    hts_base_mod_state_free(mod_state);
+    return;
+  }
+  ReadVariant *tmpReadResult = new ReadVariant();
+  (*tmpReadResult).read_name = bam_get_qname(&aln);
+  (*tmpReadResult).source_id = bamHdr.target_name[aln.core.tid];
+  (*tmpReadResult).reference_start = aln.core.pos;
+  (*tmpReadResult).is_reverse = bam_is_rev(&aln);
+
+  int refstart = aln.core.pos;
+  // forward strand is checked from head to tail
+  // reverse strand is checked from tail to head
+  int refpos = (bam_is_rev(&aln) ? refstart + 1 : refstart);
+  int ref_pos = aln.core.pos;
+  // auto qmethiter = (align.is_reverse ? align.queryMethVec.end()-1 :
+  // align.queryMethVec.begin() );
+  int querypos = 0;
+  int aln_core_n_cigar = aln.core.n_cigar;
+  uint32_t *cigar = bam_get_cigar(&aln);
+
+  hts_base_mod mods[5];
+  int pos;
+  // bam_next_basemod can iterate over this cached state.
+  int n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+  if (n <= 0) {
+    hts_base_mod_state_free(mod_state);
     delete tmpReadResult;
-}
+    return;
+  }
 
-void MethBamParser::exportResult(std::string chrName, std::string chrSquence, int chrLen, std::vector<int> &passPosition, std::ostringstream &modCallResult){
+  while (firstVariantIter != currentVariants->end() &&
+         (*firstVariantIter).first < ref_pos) {
+    firstVariantIter++;
+  }
+  // set variant start for current alignment
+  std::map<int, SnpVariant>::iterator currentVariantIter = firstVariantIter;
 
-    if(params->outputAllMod){
-        for(const auto& pair : *chrMethMap){
-            int currPos = pair.first;
-            const auto& info = pair.second;
-            
-            auto posinfoIter = chrMethMap->find(currPos);
-            if (posinfoIter == chrMethMap->end()) return;
-            std::string infostr = "";
-            std::string eachpos;
-            std::string samplestr;
-            std::string strandinfo;
-            std::string ref;
-            
-            if (chrLen < currPos) return;
+  // Parse CIGAR
+  for (int cigaridx = 0; cigaridx < int(aln.core.n_cigar); cigaridx++) {
 
-            ref = chrSquence.substr(currPos, 1);
-            if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
-                ref != "a" && ref != "t" && ref != "c" && ref != "g") return;
-
-            if (info.strand == 1) strandinfo = "RS=N;";
-            else if (info.strand == 0) strandinfo = "RS=P;";
-            else return;
-
-            // append modification reads
-            if((*posinfoIter).second.modReadVec.size() > 0 ){
-                infostr += "MR=";
-                for(auto readName : (*posinfoIter).second.modReadVec ){
-                    infostr += readName + ",";
-                }
-                infostr.back() = ';';
-            }
-                
-            // append non modification reads
-            if((*posinfoIter).second.nonModReadVec.size() > 0 ){
-                infostr += "NR=";
-                for(auto readName : (*posinfoIter).second.nonModReadVec ){
-                    infostr += readName + ",";
-                }
-                infostr.back() = ';';
-            }
-            samplestr = (*posinfoIter).second.heterstatus + ":" + std::to_string((*posinfoIter).second.methreadcnt) + ":" + std::to_string((*posinfoIter).second.canonreadcnt) + ":" + std::to_string((*posinfoIter).second.depth);
-
-            eachpos = chrName + "\t" + std::to_string((*posinfoIter).first + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
-
-            modCallResult<<eachpos;
-        }
-    }
-    else{
-        // used to track processed positions, avoid duplicate output
-        std::set<int> processedPositions;
-        // passPosition is already sorted, no need to sort again
-        for(const auto& pos : passPosition){
-            // if the position is already processed, skip
-            if(processedPositions.count(pos) > 0) {
-                continue;
-            }
-
-            // process position pos
-            auto posinfoIter = chrMethMap->find(pos);
-            if (posinfoIter != chrMethMap->end()) {
-                std::string infostr = "";
-                std::string eachpos;
-                std::string samplestr;
-                std::string strandinfo;
-                std::string ref;
-                
-                if (chrLen < pos) continue;
-
-                // avoid abnormal REF allele
-                ref = chrSquence.substr(pos, 1);
-                if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
-                    ref != "a" && ref != "t" && ref != "c" && ref != "g") continue;
-
-                if (posinfoIter->second.strand == 1) strandinfo = "RS=N;";
-                else if (posinfoIter->second.strand == 0) strandinfo = "RS=P;";
-                else continue;
-
-                // add modified reads
-                if(posinfoIter->second.modReadVec.size() > 0) {
-                    infostr += "MR=";
-                    for(auto& readName : posinfoIter->second.modReadVec) {
-                        infostr += readName + ",";
-                    }
-                    infostr.back() = ';';
-                }
-                
-                // add non-modified reads
-                if(posinfoIter->second.nonModReadVec.size() > 0) {
-                    infostr += "NR=";
-                    for(auto& readName : posinfoIter->second.nonModReadVec) {
-                        infostr += readName + ",";
-                    }
-                    infostr.back() = ';';
-                }
-                
-                // output all modified positions or only heterozygous positions
-                if(params->outputAllMod || posinfoIter->second.heterstatus == "0/1") {
-                    int nonmethcnt = posinfoIter->second.canonreadcnt;
-                    samplestr = posinfoIter->second.heterstatus + ":" + std::to_string(posinfoIter->second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string(posinfoIter->second.depth);
-                    
-                    eachpos = chrName + "\t" + std::to_string(pos + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
-                    
-                    modCallResult << eachpos;
-                }
-            }
-            processedPositions.insert(pos);
-            
-            // process position pos+1
-            int nextPos = pos + 1;
-            auto nextPosinfoIter = chrMethMap->find(nextPos);
-            if (nextPosinfoIter != chrMethMap->end() && processedPositions.count(nextPos) == 0) {
-                std::string infostr = "";
-                std::string eachpos;
-                std::string samplestr;
-                std::string strandinfo;
-                std::string ref;
-                
-                if (chrLen < nextPos) continue;
-
-                // avoid abnormal REF allele
-                ref = chrSquence.substr(nextPos, 1);
-                if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
-                    ref != "a" && ref != "t" && ref != "c" && ref != "g") continue;
-
-                if (nextPosinfoIter->second.strand == 1) strandinfo = "RS=N;";
-                else if (nextPosinfoIter->second.strand == 0) strandinfo = "RS=P;";
-                else continue;
-
-                // add modified reads
-                if(nextPosinfoIter->second.modReadVec.size() > 0) {
-                    infostr += "MR=";
-                    for(auto& readName : nextPosinfoIter->second.modReadVec) {
-                        infostr += readName + ",";
-                    }
-                    infostr.back() = ';';
-                }
-                
-                // add non-modified reads
-                if(nextPosinfoIter->second.nonModReadVec.size() > 0) {
-                    infostr += "NR=";
-                    for(auto& readName : nextPosinfoIter->second.nonModReadVec) {
-                        infostr += readName + ",";
-                    }
-                    infostr.back() = ';';
-                }
-                
-                // output all modified positions or only heterozygous positions
-                if(params->outputAllMod || nextPosinfoIter->second.heterstatus == "0/1") {
-                    int nonmethcnt = nextPosinfoIter->second.canonreadcnt;
-                    samplestr = nextPosinfoIter->second.heterstatus + ":" + std::to_string(nextPosinfoIter->second.methreadcnt) + ":" + std::to_string(nonmethcnt) + ":" + std::to_string(nextPosinfoIter->second.depth);
-                    
-                    eachpos = chrName + "\t" + std::to_string(nextPos + 1) + "\t" + "." + "\t" + ref + "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo + infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
-                    
-                    modCallResult << eachpos;
-                }
-                processedPositions.insert(nextPos);
-            }
-        }
-    }
-    
-}
-
-void writeResultVCF( ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo, std::map<std::string,std::ostringstream> &chrModCallResult){
-
-    std::ofstream modCallResultVcf(params.resultPrefix+".vcf", std::ios_base::out | std::ios_base::trunc);
-    if(!modCallResultVcf.is_open()){
-        std::cerr<<"Fail to open output file :\n";
-    }
-    else{
-        // set vcf header
-        modCallResultVcf<<"##fileformat=VCFv4.2\n";
-        modCallResultVcf<<"##INFO=<ID=RS,Number=.,Type=String,Description=\"Read Strand\">\n";
-        modCallResultVcf<<"##INFO=<ID=MR,Number=.,Type=String,Description=\"Read Name of Modified position\">\n";
-        modCallResultVcf<<"##INFO=<ID=NR,Number=.,Type=String,Description=\"Read Name of nonModified position\">\n";
-        modCallResultVcf<<"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
-        modCallResultVcf<<"##FORMAT=<ID=MD,Number=1,Type=Integer,Description=\"Modified Depth\">\n";
-        modCallResultVcf<<"##FORMAT=<ID=UD,Number=1,Type=Integer,Description=\"Unmodified Depth\">\n";
-        modCallResultVcf<<"##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">\n";
-        for(const auto& chrIter : chrInfo){
-            modCallResultVcf<<"##contig=<ID="<<chrIter.name<<",length="<<chrIter.length<<">\n";
-        }
-        modCallResultVcf << "##longphaseVersion=" << params.version << "\n";
-        modCallResultVcf << "##commandline=\""    << params.command << "\"\n";
-        modCallResultVcf<<"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n";
-        
-        // set vcf body
-        for(const auto& chrIter : chrInfo){
-            modCallResultVcf << chrModCallResult[chrIter.name].str();
-        }
-    }
-}
-
-void MethBamParser::judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &modReadVariantVec){
-    //Find all methylation sites and determine their genotypes
-    for(std::map<int, MethPosInfo>::iterator chrmethmapIter = chrMethMap->begin(); chrmethmapIter != chrMethMap->end(); chrmethmapIter++){
-
-        // Determine methylation genotype
-        float methcnt      = (*chrmethmapIter).second.methreadcnt;
-        float nonmethcnt   = (*chrmethmapIter).second.canonreadcnt;
-        float depth        = (*chrmethmapIter).second.depth;
-        float noisereadcnt = depth - methcnt - nonmethcnt;
-        
-        if(methcnt < 0 || nonmethcnt < 0){
-            continue;
-        }
-        if(std::max(methcnt, nonmethcnt) == 0){
-            continue;
-        }
-        
-        float heterRatio = std::min(methcnt, nonmethcnt) / std::max(methcnt, nonmethcnt);
-        float noiseRatio = noisereadcnt / depth;
-        
-        // Determine methylation genotype for each position individually
-        if(heterRatio >= params->heterRatio && noiseRatio <= params->noiseRatio){
-            (*chrmethmapIter).second.heterstatus = "0/1";
-        }
-        else if(methcnt >= nonmethcnt){
-            (*chrmethmapIter).second.heterstatus = "1/1";
-        }
-        else{
-            (*chrmethmapIter).second.heterstatus = "0/0";
-        }
-    }
-    
-    std::set<int> positionPairs; 
-
-    // Only process cases with forward-reverse strand pairs
-    for(auto iter = chrMethMap->begin(); iter != chrMethMap->end(); iter++){        
-        if(iter->second.strand == 0 && iter->second.variantType == VariantType::MOD){
-            int currPos = iter->first;
-            int nextPos = currPos + 1; 
-            
-            auto nextIter = chrMethMap->find(nextPos);
-            // Check that the next position exists, is on the reverse strand, and is a methylation site
-            if(nextIter != chrMethMap->end() && nextIter->second.strand == 1 && nextIter->second.variantType == VariantType::MOD){
-                // Calculate methylation statistics after combining
-                float totalMethCnt = iter->second.methreadcnt + nextIter->second.methreadcnt;
-                float totalNonMethCnt = iter->second.canonreadcnt + nextIter->second.canonreadcnt;
-                float totalDepth = iter->second.depth + nextIter->second.depth;
-                float totalNoiseCnt = totalDepth - totalMethCnt - totalNonMethCnt;
-                
-                if(std::max(totalMethCnt, totalNonMethCnt) == 0){
-                    continue;
-                }
-                
-                float combinedHeterRatio = std::min(totalMethCnt, totalNonMethCnt) / std::max(totalMethCnt, totalNonMethCnt);
-                float combinedNoiseRatio = totalNoiseCnt / totalDepth;
-                
-                // Determine methylation genotype based on combined data
-                std::string combinedStatus;
-                if(combinedHeterRatio >= params->heterRatio && combinedNoiseRatio <= params->noiseRatio){
-                    combinedStatus = "0/1";
-                    positionPairs.insert(currPos);
-                }
-                else if(totalMethCnt >= totalNonMethCnt){
-                    combinedStatus = "1/1";
-                }
-                else{
-                    combinedStatus = "0/0";
-                }                
-                // Update the status of forward and reverse strand positions
-                iter->second.heterstatus = combinedStatus;
-                nextIter->second.heterstatus = combinedStatus;
-            }
-        }
-    }
-
-    // Handle all variants uniformly to avoid duplication
-    for(auto& read : readVariantVec){
-        ReadVariant newRead;
-        newRead.read_name = read.read_name;
-        newRead.is_reverse = read.is_reverse;
-        
-        for(auto& variant : read.variantVec){
-            int pos = variant.position;
-            // Check if the variant is methylation-related and marked as heterogeneous in chrMethMap
-            if(variant.type == VariantType::MOD) {
-                auto methPosIter = chrMethMap->find(pos);
-                if(methPosIter == chrMethMap->end()){
-                    continue;
-                }
-                if(methPosIter->second.strand == 0){
-                    auto pairIter = positionPairs.find(pos);
-                    if(pairIter != positionPairs.end()){
-                        newRead.variantVec.emplace_back(pos, variant.allele, variant.quality, VariantType::MOD);
-                    }
-                }
-                else if(methPosIter->second.strand == 1){
-                    auto pairIter = positionPairs.find(pos-1);
-                    if(pairIter != positionPairs.end()){
-                        newRead.variantVec.emplace_back(pos-1, variant.allele, variant.quality, VariantType::MOD);
-                    }
-                }
-            } 
-            else if(variant.type == VariantType::SNP) {
-                newRead.variantVec.emplace_back(variant);
-            }
-        }
-        if(!newRead.variantVec.empty()){
-            modReadVariantVec.push_back(newRead);
-        }
-        newRead.variantVec.clear();
-        newRead.variantVec.shrink_to_fit();
-    }
-}
-
-void MethBamParser::calculateDepth(){
-    std::map<int , MethPosInfo>::iterator methIter = chrMethMap->begin();
-    std::pair<int,int> currdepth = std::make_pair(0,0);
-    
-    for(auto ReadIter = readStartEndMap->begin(); ReadIter != readStartEndMap->end(); ReadIter++){
-        
-        std::map<int, std::pair<int,int>>::iterator nextReadIter = std::next(ReadIter, 1);
-        if(methIter == chrMethMap->end()){
-            break;
-        }
-        if(nextReadIter == readStartEndMap->end()){
-            break;
-        }
-        currdepth.first += (*ReadIter).second.first;
-        currdepth.second += (*ReadIter).second.second;
-        
-        while(methIter != chrMethMap->end() && (*methIter).first >= (*ReadIter).first && (*methIter).first < (*nextReadIter).first){
-            
-            // strand +
-            if((*methIter).second.strand == 0){ 
-                (*methIter).second.depth = currdepth.first;
-            }
-            // strand -
-            else if((*methIter).second.strand == 1){
-                (*methIter).second.depth = currdepth.second;
-            }
-            
-            methIter++;
-        }
-    }
-    
-    readStartEndMap->clear();
-}
-
-MethylationGraph::MethylationGraph(ModCallParameters &in_params){
-    params=&in_params;
-    nodeInfo = new std::map<int, std::map<std::string, VariantType>>;
-    edgeList = new std::map<int,VariantEdge*>;
-    forwardModNode = new std::map<int,ReadBaseMap*>;
-    reverseModNode = new std::map<int,ReadBaseMap*>;
-}
-
-MethylationGraph::~MethylationGraph(){
-}
-
-void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant, std::string chrName){
-    readVariant = &in_readVariant;
-    int readCount = 0;
-    int vectorSize = 0;
-    // iter all read
-    for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
-        ReadVariant tmpRead;
-        vectorSize += (*readIter).variantVec.size();
-        readCount++;
-        
-        for( auto variant : (*readIter).variantVec ){           
-            auto nodeIter = nodeInfo->find(variant.position);
-            
-            if( nodeIter == nodeInfo->end() ){
-                (*nodeInfo)[variant.position] = std::map<std::string, VariantType>();
-            }
-            (*nodeInfo)[variant.position][(*readIter).read_name] = variant.type;
-        }
-
-        for (auto variant1Iter = (*readIter).variantVec.begin(); variant1Iter != (*readIter).variantVec.end(); ++variant1Iter) {
-            auto variant2Iter = std::next(variant1Iter);
-            int searchCount = 0;
-            while (variant2Iter != (*readIter).variantVec.end() && searchCount < 50) {
-                if (!(variant1Iter->type == VariantType::SNP && variant2Iter->type == VariantType::SNP) ) {
-
-                    int pos = variant1Iter->position;
-                    auto edgeIter = edgeList->find(pos);
-                    if (edgeIter == edgeList->end()) {
-                        (*edgeList)[pos] = new VariantEdge(pos);
-                    }
-
-                    if (variant1Iter->allele == 0) {
-                        (*edgeList)[pos]->ref->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
-                    } 
-                    else if (variant1Iter->allele == 1) {
-                        (*edgeList)[pos]->alt->addSubEdge(variant1Iter->quality, *variant2Iter, readIter->read_name, 0, 1);
-                    }
-                }
-                ++searchCount;
-                ++variant2Iter;
-            }
-        }
-    }
-}
-
-void MethylationGraph::connectResults(std::string chrName, std::vector<int> &passPosition, bool hasValidSnpData){
-    std::set<int> strongMethylationPoints;
-    std::set<int> weakMethylationPoints;
-    std::set<int> weakMethylationPoints2;
-    std::set<int> addedPositions;
-    std::set<int> addedPositions2;
-    std::vector<int> prepassPosition;
-    std::vector<int> hasConnect;
-
-    // If no valid SNP data, skip the first pass and directly add all methylation sites to strongMethylationPoints
-    if (!hasValidSnpData) {
-        for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end(); ++nodeIter) {
-            int currPos = nodeIter->first;
-            if(checkVariantType(currPos) == VariantType::MOD){
-                strongMethylationPoints.insert(currPos);
-            }
-        }
-    }
-    else {
-        // First pass: Identify methylation points with strong SNP connections
-        for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end(); ++nodeIter) {
-            int currPos = nodeIter->first;
-            auto nextNodeIter = std::next(nodeIter, 1);
-            int searchCount = 0;
-            if( nextNodeIter == nodeInfo->end() ){
-                break;
-            }
-
-            auto edgeIter = edgeList->find(currPos);
-            if (edgeIter == edgeList->end()) 
-                continue;
-
-            if(checkVariantType(currPos) == 0){
-                auto searchNodeIter = nextNodeIter;
-                // Continue searching until we find a SNP or reach the end of nodeInfo
-                while (searchNodeIter != nodeInfo->end() && searchCount < params->connectAdjacent) {
-                    std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(searchNodeIter->first);
-                    int totalConnectReads = tmp.first + tmp.second;
-                    float minimumConnection = std::max(((*nodeIter).second.size() + (*searchNodeIter).second.size())/ 4.0, 6.0);
-                    if(totalConnectReads <= minimumConnection){
-                        break;
-                    }
-                    if(checkVariantType(searchNodeIter->first) == VariantType::SNP) {     
-                        double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-                        hasConnect.push_back(currPos);
-                        if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && strongMethylationPoints.count(currPos) == 0) {
-                            strongMethylationPoints.insert(currPos);
-                            break;
-                        }
-                    }
-                    ++searchNodeIter;
-                    ++searchCount;
-                }
-                if(std::find(hasConnect.begin(), hasConnect.end(), currPos) == hasConnect.end()){
-                    weakMethylationPoints.insert(currPos);
-                }
-            }
-            else if(checkVariantType(currPos) == VariantType::SNP){
-                auto searchNodeIter = nextNodeIter;
-                prepassPosition.push_back(currPos);
-                while(searchNodeIter != nodeInfo->end()) {
-                    std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(searchNodeIter->first);
-                    int totalConnectReads = tmp.first + tmp.second;
-                    float minimumConnection = std::max(((*nodeIter).second.size() + (*searchNodeIter).second.size())/ 4.0, 6.0);
-                    if(totalConnectReads <= minimumConnection){
-                        break;
-                    }
-                    if (checkVariantType(searchNodeIter->first) == VariantType::MOD) {
-                        double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-                        hasConnect.push_back(searchNodeIter->first);
-                        if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection && strongMethylationPoints.count(nextNodeIter->first) == 0) {
-                            strongMethylationPoints.insert(nextNodeIter->first);
-                        } 
-                    }
-                    ++searchNodeIter;      
-                    ++searchCount;
-                }
-            }
-        }
-    } 
-    hasConnect.clear();
-
-    // Second pass: Evaluate connections between strong methylation points
-    for(auto it1 = strongMethylationPoints.begin(); it1 != strongMethylationPoints.end(); ++it1){
-        int pos1 = *it1;
-        auto it2 = std::next(it1, 1);
-        auto searchNodeIter = it2;
-        int searchCount = 0;
-        auto edgeIter = edgeList->find(pos1);
-        if (edgeIter == edgeList->end()) 
-            continue;
-
-        while(searchNodeIter != strongMethylationPoints.end() && searchCount < params->connectAdjacent) {
-            int pos2 = *searchNodeIter;
-            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos2);
-            int totalConnectReads = tmp.first + tmp.second;
-            float minimumConnection = std::max(((*nodeInfo)[pos1].size() + (*nodeInfo)[pos2].size())/ 4.0, 6.0);
-            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-
-            if(totalConnectReads <= minimumConnection){
-                break;
-            }
-
-            if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection) {
-                if(addedPositions.count(pos1) == 0) {
-                    prepassPosition.push_back(pos1);
-                    addedPositions.insert(pos1);
-                    // Only add positions to weakMethylationPoints if there is valid SNP data (for third pass)
-                    if(hasValidSnpData) {
-                        weakMethylationPoints.insert(pos1);
-                    }
-                }
-                if(addedPositions.count(pos2) == 0) {
-                    prepassPosition.push_back(pos2);
-                    addedPositions.insert(pos2);
-                    // Only add positions to weakMethylationPoints if there is valid SNP data (for third pass)
-                    if(hasValidSnpData) {
-                        weakMethylationPoints.insert(pos2);
-                    }
-                }
-            }
-            ++searchNodeIter;
-            ++searchCount;
-        }
-    }
-    strongMethylationPoints.clear();
-
-    //third pass: evaluate connections between weak methylation points
-    for(int i = 0; i < params->iterCount; i++){
-        if (hasValidSnpData) {
-            // Use alternating sets for each iteration
-            auto& currentWeakPoints = (i % 2 == 0) ? weakMethylationPoints : weakMethylationPoints2;
-            auto& nextWeakPoints = (i % 2 == 0) ? weakMethylationPoints2 : weakMethylationPoints;
-            auto& currentAddedPositions = (i % 2 == 0) ? addedPositions : addedPositions2;
-            auto& nextAddedPositions = (i % 2 == 0) ? addedPositions2 : addedPositions;
-            
-            // Clear the target set for this iteration
-            nextWeakPoints.clear();
-            nextAddedPositions.clear();
-            
-            for(auto it1 = currentWeakPoints.begin(); it1 != currentWeakPoints.end(); ++it1){
-                int currPos = *it1;
-                auto nextIter = it1;
-                int nextSearchCount = 0;
-                bool isAdded = false;
-                auto edgeIter = edgeList->find(currPos);
-                if (edgeIter == edgeList->end()) 
-                    continue;
-                while(++nextIter != currentWeakPoints.end() && nextSearchCount < params->connectAdjacent) {
-                    int nextPos = *nextIter;
-                    if(currentAddedPositions.count(nextPos) == 0 && currentAddedPositions.count(currPos) == 0){
-                        ++nextSearchCount;
-                        continue;
-                    }
-                    isAdded = true;
-                    std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
-                    int totalConnectReads = tmp.first + tmp.second;
-                    float minimumConnection = std::max(((*nodeInfo)[currPos].size() + (*nodeInfo)[nextPos].size())/ 4.0, 6.0);
-                    double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-                    if(totalConnectReads <= minimumConnection){
-                        break;
-                    }
-                    if (majorRatio >= params->connectConfidence && totalConnectReads > minimumConnection ) {
-                        if(std::find(prepassPosition.begin(), prepassPosition.end(), currPos) == prepassPosition.end()){
-                            prepassPosition.push_back(currPos);
-                            nextWeakPoints.insert(currPos);
-                            nextAddedPositions.insert(currPos);
-                        }
-                        if(std::find(prepassPosition.begin(), prepassPosition.end(), nextPos) == prepassPosition.end()){
-                            prepassPosition.push_back(nextPos);
-                            nextWeakPoints.insert(nextPos);
-                            nextAddedPositions.insert(nextPos);
-                        }
-                    }
-                    ++nextSearchCount;
-                }
-                if(!isAdded){
-                    nextWeakPoints.insert(currPos);
-                }
-            }
-        }
-    }
-    weakMethylationPoints.clear();
-    weakMethylationPoints2.clear();
-    addedPositions.clear();
-    addedPositions2.clear();
-
-    // Ensure passPosition is sorted by position
-    std::sort(prepassPosition.begin(), prepassPosition.end());
-    // Fourth step: Filter positions that do not have good connections to both neighbors
-    for (size_t i = 0; i < prepassPosition.size(); ++i) {
-        int pos = prepassPosition[i];
-        bool hasGoodPrevConnection = false;
-        bool hasGoodNextConnection = false;
-        if(nodeInfo->find(pos) != nodeInfo->end()){
-            if(checkVariantType(pos) == VariantType::SNP){
-                continue;
-            }
-        }
-                
-        // Check connection with previous position
-        if (i > 0) {
-            int prevPos = prepassPosition[i-1];
-            auto edgeIter = edgeList->find(prevPos);
-            if (edgeIter == edgeList->end()) {
-                hasGoodPrevConnection = true;
-                continue;
-            }
-            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos);
-            int totalConnectReads = tmp.first + tmp.second;
-            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-            if(totalConnectReads != 0){
-                
-                if (majorRatio >= params->connectConfidence && totalConnectReads >= 6 ) {
-                    hasGoodPrevConnection = true;
-                }
-            }
-        }
-        
-        // Check connection with next position
-        if (i < prepassPosition.size() - 1 && hasGoodPrevConnection) {
-            int nextPos = prepassPosition[i+1];
-            auto edgeIter = edgeList->find(pos);
-            if (edgeIter == edgeList->end()) {
-                hasGoodNextConnection = true;
-                continue;
-            }
-            std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
-            int totalConnectReads = tmp.first + tmp.second;
-            double majorRatio = (double)std::max(tmp.first, tmp.second) / (double)(tmp.first + tmp.second);
-            if(totalConnectReads != 0){
-                if (majorRatio >= params->connectConfidence && totalConnectReads >= 6 ) {
-                    hasGoodNextConnection = true;
-                }
-            }
-        }
-        
-        // Only keep positions with good connections to both neighbors (or edge positions)
-        if ( hasGoodNextConnection || i == 0 || i == prepassPosition.size() - 1) {
-            passPosition.push_back(pos);
-        }
-    }
-    prepassPosition.clear();
-}
-
-int MethylationGraph::checkVariantType(int position){
-    auto nodeIter = nodeInfo->find(position);
-    if (nodeIter != nodeInfo->end()) {
-        for (const auto& nodeType : nodeIter->second) {
-            if(nodeType.second == VariantType::MOD){
-                return VariantType::MOD; // Return true if any type is MOD
-            }
-            else if(nodeType.second == VariantType::SNP){
-                return VariantType::SNP; // Return true if any type is SNP
-            }
-            else if(nodeType.second == VariantType::INDEL){
-                return VariantType::INDEL; // Return true if any type is INDEL
-            }
-            else if(nodeType.second == VariantType::SV){
-                return VariantType::SV; // Return true if any type is SV
-            }
-            else{
-                return -1; // Return -1 if no variant type is found
-            }
-        }
-    }
-    return -1; // Return -1 if the position is not in the nodeInfo
-}
-
-void MethylationGraph::destroy(){
-
-    for( auto edgeIter = edgeList->begin() ; edgeIter != edgeList->end() ; edgeIter++ ){
-        edgeIter->second->ref->destroy();
-        edgeIter->second->alt->destroy();
-        delete edgeIter->second->ref;
-        delete edgeIter->second->alt;
-    }
-    
-    for( auto nodeIter = forwardModNode->begin() ; nodeIter != forwardModNode->end() ; nodeIter++ ){
-        delete nodeIter->second;
-    }
-    
-    for( auto nodeIter = reverseModNode->begin() ; nodeIter != reverseModNode->end() ; nodeIter++ ){
-        delete nodeIter->second;
-    }
-    
-    delete nodeInfo;
-    delete edgeList;
-}
-
-MethSnpParser::MethSnpParser(ModCallParameters &in_params):commandLine(false), hasSnpData(false){
-    chrVariant = new std::map<std::string, std::map<int, RefAlt> >;
-    
-    params = &in_params;
-    
-    // Check if SNP file is provided
-    if(params->snpFile.empty()) {
-        std::cerr << "No SNP file provided, running without SNP variants.";
-        return; 
-    }
-    
-    // open vcf file
-    htsFile * inf = bcf_open(params->snpFile.c_str(), "r");
-    if(inf == nullptr) {
-        std::cerr << "Warning: Could not open SNP file " << params->snpFile << ", running without SNP variants.";
+    int cigar_op = bam_cigar_op(cigar[cigaridx]);
+    int length = bam_cigar_oplen(cigar[cigaridx]);
+    if (cigar_op == 0 || cigar_op == 7 || cigar_op == 8) {
+      if (!extractSnpAllele(currentVariantIter, ref_pos, length, querypos,
+                            cigaridx, aln_core_n_cigar, cigar, aln,
+                            tmpReadResult)) {
         return;
+      }
     }
-    
-    // read header
-    bcf_hdr_t *hdr = bcf_hdr_read(inf);
-    if(hdr == nullptr) {
-        std::cerr << "Warning: Could not read SNP file header, running without SNP variants.";
-        bcf_close(inf);
-        return;
-    }
-    // counters
-    int nseq = 0;
-    // report names of all the sequences in the VCF file
-    const char **seqnames = NULL;
-    // chromosome idx and name
-    seqnames = bcf_hdr_seqnames(hdr, &nseq);
-    // store chromosome
-    for (int i = 0; i < nseq; i++) {
-        // bcf_hdr_id2name is another way to get the name of a sequence
-        chrName.emplace_back(seqnames[i]);
-    }
-    // set all sample string
-    std::string allSmples = "-";
-    // limit the VCF data to the sample name passed in
-    int is_file = bcf_hdr_set_samples(hdr, allSmples.c_str(), 0);
-    if( is_file != 0 ){
-        std::cout << "error or a positive integer if the list contains samples not present in the VCF header\n";
-    }
+    // else break;
+    //}
 
-    // struct for storing each record
-    bcf1_t *rec = bcf_init();
-    int ngt_arr = 0;
-    int ngt = 0;
-    int *gt     = NULL;
-    
-    // loop vcf line 
-    while (bcf_read(inf, hdr, rec) == 0) {
-        // snp
-        if (bcf_is_snp(rec)) {
-            ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
+    // CIGAR operators: MIDNSHP=X correspond 012345678
+    // 0: alignment match (can be a sequence match or mismatch)
+    // 7: sequence match
+    // 8: sequence mismatch
 
-            if(ngt<0){
-                std::cerr<< "pos " << rec->pos << " missing GT value" << "\n";
-                exit(1);
-            }
-            
-            // just phase hetero SNP
-            if ( (gt[0] == 2 && gt[1] == 4) || // 0/1
-                 (gt[0] == 4 && gt[1] == 2) || // 1/0
-                 (gt[0] == 2 && gt[1] == 5) || // 0|1
-                 (gt[0] == 4 && gt[1] == 3)    // 1|0 
-                ) {
-                
-                // get chromosome string
-                std::string chr = seqnames[rec->rid];
-                // position is 0-base
-                int variantPos = rec->pos;
-                // get r alleles
-                RefAlt tmp;
-                tmp.Ref = rec->d.allele[0]; 
-                tmp.Alt = rec->d.allele[1];
-                
-                //prevent the MAVs calling error which makes the GT=0/1
-                if ( rec->d.allele[1][2] != '\0' ){
-                    continue;
-                }
-                
-                // record 
-                (*chrVariant)[chr][variantPos] = tmp;
-            }
+    if (cigar_op == 0 || cigar_op == 7 || cigar_op == 8) {
+      classifyMethylationBase(n, pos, mods, querypos, length, refpos, aln,
+                              tmpReadResult, mod_state);
+      querypos += length;
+      refpos += length;
+      ref_pos += length;
+    }
+    // 1: insertion to the reference
+    else if (cigar_op == 1) {
+      while (n > 0 && pos <= (querypos + length)) {
+        n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+      }
+      querypos += length;
+    }
+    // 2: deletion from the reference
+    else if (cigar_op == 2) {
+      if (*refString != "") {
+        if (currentVariantIter == currentVariants->end()) {
+          refpos += length;
+          ref_pos += length;
+          continue;
         }
+        if (!handleDeletionInHomopolymer(currentVariantIter, ref_pos, length,
+                                         querypos, aln, mod_state,
+                                         tmpReadResult)) {
+          delete tmpReadResult;
+          return;
+        }
+      }
+      refpos += length;
+      ref_pos += length;
     }
-    
-    // Clean up resources
-    if(gt) free(gt);
-    bcf_destroy(rec);
-    bcf_hdr_destroy(hdr);
+    // 3: skipped region from the reference
+    else if (cigar_op == 3) {
+      refpos += length;
+      ref_pos += length;
+    }
+    // 4: soft clipping (clipped sequences present in SEQ)
+    else if (cigar_op == 4) {
+      while (n > 0 && pos <= (querypos + length)) {
+        n = bam_next_basemod(&aln, mod_state, mods, 5, &pos);
+      }
+      querypos += length;
+    }
+    // 5: hard clipping (clipped sequences NOT present in SEQ)
+    // 6: padding (silent deletion from padded reference)
+    else if (cigar_op == 5 || cigar_op == 6) {
+      // do nothing
+      refpos += length;
+    }
+  }
+
+  hts_base_mod_state_free(mod_state);
+
+  updateDepthBoundary(refstart, refpos, bam_is_rev(&aln));
+
+  if ((*tmpReadResult).variantVec.size() > 0) {
+    (*tmpReadResult).sort();
+    readVariantVec.emplace_back((*tmpReadResult));
+  }
+  delete tmpReadResult;
+}
+
+std::string MethBamParser::buildInfoStr(const MethPosInfo &info) const {
+  std::string infostr;
+  if (info.modReadVec.size() > 0) {
+    infostr += "MR=";
+    for (const auto &readName : info.modReadVec) {
+      infostr += readName + ",";
+    }
+    infostr.back() = ';';
+  }
+
+  if (info.nonModReadVec.size() > 0) {
+    infostr += "NR=";
+    for (const auto &readName : info.nonModReadVec) {
+      infostr += readName + ",";
+    }
+    infostr.back() = ';';
+  }
+
+  return infostr;
+}
+
+std::string MethBamParser::formatMethVcfLine(
+    int pos, const MethPosInfo &info, const std::string &chrSequence,
+    int chrLen) const {
+  if (chrLen < pos)
+    return "";
+
+  std::string ref = chrSequence.substr(pos, 1);
+  if (ref != "A" && ref != "T" && ref != "C" && ref != "G" &&
+      ref != "a" && ref != "t" && ref != "c" && ref != "g")
+    return "";
+
+  std::string strandinfo;
+  if (info.strand == 1)
+    strandinfo = "RS=N;";
+  else if (info.strand == 0)
+    strandinfo = "RS=P;";
+  else
+    return "";
+
+  std::string infostr = buildInfoStr(info);
+  std::string samplestr = info.heterstatus + ":" +
+                          std::to_string(info.methreadcnt) + ":" +
+                          std::to_string(info.canonreadcnt) + ":" +
+                          std::to_string(info.depth);
+
+  return chrName + "\t" + std::to_string(pos + 1) + "\t" + "." + "\t" + ref +
+         "\t" + "N" + "\t" + "." + "\t" + "PASS" + "\t" + strandinfo +
+         infostr + "\t" + "GT:MD:UD:DP" + "\t" + samplestr + "\n";
+}
+
+void MethBamParser::exportResult(std::string chrName, std::string chrSquence,
+                                 int chrLen, std::vector<int> &passPosition,
+                                 std::ostringstream &modCallResult) {
+
+  if (params->outputAllMod) {
+    for (const auto &pair : *chrMethMap) {
+      std::string line =
+          formatMethVcfLine(pair.first, pair.second, chrSquence, chrLen);
+      if (line.empty())
+        return;
+      modCallResult << line;
+    }
+  } else {
+    // used to track processed positions, avoid duplicate output
+    std::set<int> processedPositions;
+    // passPosition is already sorted, no need to sort again
+    for (const auto &pos : passPosition) {
+      // if the position is already processed, skip
+      if (processedPositions.count(pos) > 0) {
+        continue;
+      }
+
+      // process position pos
+      auto posinfoIter = chrMethMap->find(pos);
+      if (posinfoIter != chrMethMap->end()) {
+        // output all modified positions or only heterozygous positions
+        if (params->outputAllMod || posinfoIter->second.heterstatus == "0/1") {
+          std::string line =
+              formatMethVcfLine(pos, posinfoIter->second, chrSquence, chrLen);
+          if (line.empty())
+            continue;
+          modCallResult << line;
+        }
+      }
+      processedPositions.insert(pos);
+
+      // process position pos+1
+      int nextPos = pos + 1;
+      auto nextPosinfoIter = chrMethMap->find(nextPos);
+      if (nextPosinfoIter != chrMethMap->end() &&
+          processedPositions.count(nextPos) == 0) {
+        // output all modified positions or only heterozygous positions
+        if (params->outputAllMod ||
+            nextPosinfoIter->second.heterstatus == "0/1") {
+          std::string line = formatMethVcfLine(
+              nextPos, nextPosinfoIter->second, chrSquence, chrLen);
+          if (line.empty())
+            continue;
+          modCallResult << line;
+        }
+        processedPositions.insert(nextPos);
+      }
+    }
+  }
+}
+
+void writeResultVCF(
+    ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo,
+    std::map<std::string, std::ostringstream> &chrModCallResult) {
+
+  std::ofstream modCallResultVcf(params.resultPrefix + ".vcf",
+                                 std::ios_base::out | std::ios_base::trunc);
+  if (!modCallResultVcf.is_open()) {
+    std::cerr << "Fail to open output file :\n";
+  } else {
+    // set vcf header
+    modCallResultVcf << "##fileformat=VCFv4.2\n";
+    modCallResultVcf
+        << "##INFO=<ID=RS,Number=.,Type=String,Description=\"Read Strand\">\n";
+    modCallResultVcf << "##INFO=<ID=MR,Number=.,Type=String,Description=\"Read "
+                        "Name of Modified position\">\n";
+    modCallResultVcf << "##INFO=<ID=NR,Number=.,Type=String,Description=\"Read "
+                        "Name of nonModified position\">\n";
+    modCallResultVcf
+        << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
+    modCallResultVcf << "##FORMAT=<ID=MD,Number=1,Type=Integer,Description="
+                        "\"Modified Depth\">\n";
+    modCallResultVcf << "##FORMAT=<ID=UD,Number=1,Type=Integer,Description="
+                        "\"Unmodified Depth\">\n";
+    modCallResultVcf << "##FORMAT=<ID=DP,Number=1,Type=Integer,Description="
+                        "\"Read Depth\">\n";
+    for (const auto &chrIter : chrInfo) {
+      modCallResultVcf << "##contig=<ID=" << chrIter.name
+                       << ",length=" << chrIter.length << ">\n";
+    }
+    modCallResultVcf << "##longphaseVersion=" << params.version << "\n";
+    modCallResultVcf << "##commandline=\"" << params.command << "\"\n";
+    modCallResultVcf
+        << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n";
+
+    // set vcf body
+    for (const auto &chrIter : chrInfo) {
+      modCallResultVcf << chrModCallResult[chrIter.name].str();
+    }
+  }
+}
+
+void MethBamParser::computeSinglePositionGenotype() {
+  for (std::map<int, MethPosInfo>::iterator chrmethmapIter =
+           chrMethMap->begin();
+       chrmethmapIter != chrMethMap->end(); chrmethmapIter++) {
+
+    float methcnt = (*chrmethmapIter).second.methreadcnt;
+    float nonmethcnt = (*chrmethmapIter).second.canonreadcnt;
+    float depth = (*chrmethmapIter).second.depth;
+    float noisereadcnt = depth - methcnt - nonmethcnt;
+
+    if (methcnt < 0 || nonmethcnt < 0) {
+      continue;
+    }
+    if (std::max(methcnt, nonmethcnt) == 0) {
+      continue;
+    }
+
+    float heterRatio =
+        std::min(methcnt, nonmethcnt) / std::max(methcnt, nonmethcnt);
+    float noiseRatio = noisereadcnt / depth;
+
+    if (heterRatio >= params->heterRatio && noiseRatio <= params->noiseRatio) {
+      (*chrmethmapIter).second.heterstatus = "0/1";
+    } else if (methcnt >= nonmethcnt) {
+      (*chrmethmapIter).second.heterstatus = "1/1";
+    } else {
+      (*chrmethmapIter).second.heterstatus = "0/0";
+    }
+  }
+}
+
+std::set<int> MethBamParser::applyCpGStrandPairGenotype() {
+  std::set<int> positionPairs;
+
+  for (auto iter = chrMethMap->begin(); iter != chrMethMap->end(); iter++) {
+    if (iter->second.strand == 0 &&
+        iter->second.variantType == VariantType::MOD) {
+      int currPos = iter->first;
+      int nextPos = currPos + 1;
+
+      auto nextIter = chrMethMap->find(nextPos);
+      if (nextIter != chrMethMap->end() && nextIter->second.strand == 1 &&
+          nextIter->second.variantType == VariantType::MOD) {
+        float totalMethCnt =
+            iter->second.methreadcnt + nextIter->second.methreadcnt;
+        float totalNonMethCnt =
+            iter->second.canonreadcnt + nextIter->second.canonreadcnt;
+        float totalDepth = iter->second.depth + nextIter->second.depth;
+        float totalNoiseCnt = totalDepth - totalMethCnt - totalNonMethCnt;
+
+        if (std::max(totalMethCnt, totalNonMethCnt) == 0) {
+          continue;
+        }
+
+        float combinedHeterRatio = std::min(totalMethCnt, totalNonMethCnt) /
+                                   std::max(totalMethCnt, totalNonMethCnt);
+        float combinedNoiseRatio = totalNoiseCnt / totalDepth;
+
+        std::string combinedStatus;
+        if (combinedHeterRatio >= params->heterRatio &&
+            combinedNoiseRatio <= params->noiseRatio) {
+          combinedStatus = "0/1";
+          positionPairs.insert(currPos);
+        } else if (totalMethCnt >= totalNonMethCnt) {
+          combinedStatus = "1/1";
+        } else {
+          combinedStatus = "0/0";
+        }
+        iter->second.heterstatus = combinedStatus;
+        nextIter->second.heterstatus = combinedStatus;
+      }
+    }
+  }
+
+  return positionPairs;
+}
+
+void MethBamParser::filterModReadVariants(
+    const std::set<int> &positionPairs,
+    std::vector<ReadVariant> &readVariantVec,
+    std::vector<ReadVariant> &modReadVariantVec) {
+  for (auto &read : readVariantVec) {
+    ReadVariant newRead;
+    newRead.read_name = read.read_name;
+    newRead.is_reverse = read.is_reverse;
+
+    for (auto &variant : read.variantVec) {
+      int pos = variant.position;
+      if (variant.type == VariantType::MOD) {
+        auto methPosIter = chrMethMap->find(pos);
+        if (methPosIter == chrMethMap->end()) {
+          continue;
+        }
+        if (methPosIter->second.strand == 0) {
+          if (positionPairs.count(pos)) {
+            newRead.variantVec.emplace_back(pos, variant.allele,
+                                            variant.quality, VariantType::MOD);
+          }
+        } else if (methPosIter->second.strand == 1) {
+          // normalize reverse-strand position to forward-strand CpG coordinate
+          if (positionPairs.count(pos - 1)) {
+            newRead.variantVec.emplace_back(pos - 1, variant.allele,
+                                            variant.quality, VariantType::MOD);
+          }
+        }
+      } else if (variant.type == VariantType::SNP) {
+        newRead.variantVec.emplace_back(variant);
+      }
+    }
+    if (!newRead.variantVec.empty()) {
+      modReadVariantVec.push_back(newRead);
+    }
+    newRead.variantVec.clear();
+    newRead.variantVec.shrink_to_fit();
+  }
+}
+
+void MethBamParser::judgeMethGenotype(
+    std::string chrName, std::vector<ReadVariant> &readVariantVec,
+    std::vector<ReadVariant> &modReadVariantVec) {
+  computeSinglePositionGenotype();
+  std::set<int> positionPairs = applyCpGStrandPairGenotype();
+  filterModReadVariants(positionPairs, readVariantVec, modReadVariantVec);
+}
+
+void MethBamParser::dumpMethMap(const std::string &chrName,
+                                std::ofstream &out) const {
+  for (const auto &entry : *chrMethMap) {
+    out << chrName << "\t" << entry.first << "\t"
+        << entry.second.methreadcnt << "\t" << entry.second.canonreadcnt
+        << "\t" << entry.second.noisereadcnt << "\t"
+        << static_cast<int>(entry.second.variantType) << "\t"
+        << entry.second.strand << "\n";
+  }
+}
+
+void MethBamParser::dumpReadStartEnd(const std::string &chrName,
+                                     std::ofstream &out) const {
+  for (const auto &entry : *readStartEndMap) {
+    out << chrName << "\t" << entry.first << "\t" << entry.second.first
+        << "\t" << entry.second.second << "\n";
+  }
+}
+
+void MethBamParser::dumpMethGenoMap(const std::string &chrName,
+                                    std::ofstream &out) const {
+  for (const auto &entry : *chrMethMap) {
+    out << chrName
+        << "\t" << entry.first
+        << "\t" << entry.second.heterstatus
+        << "\n";
+  }
+}
+
+void MethBamParser::calculateDepth() {
+  std::map<int, MethPosInfo>::iterator methIter = chrMethMap->begin();
+  std::pair<int, int> currdepth = std::make_pair(0, 0);
+
+  for (auto ReadIter = readStartEndMap->begin();
+       ReadIter != readStartEndMap->end(); ReadIter++) {
+
+    std::map<int, std::pair<int, int>>::iterator nextReadIter =
+        std::next(ReadIter, 1);
+    if (methIter == chrMethMap->end()) {
+      break;
+    }
+    if (nextReadIter == readStartEndMap->end()) {
+      break;
+    }
+    currdepth.first += (*ReadIter).second.first;
+    currdepth.second += (*ReadIter).second.second;
+
+    while (methIter != chrMethMap->end() &&
+           (*methIter).first >= (*ReadIter).first &&
+           (*methIter).first < (*nextReadIter).first) {
+
+      // strand +
+      if ((*methIter).second.strand == 0) {
+        (*methIter).second.depth = currdepth.first;
+      }
+      // strand -
+      else if ((*methIter).second.strand == 1) {
+        (*methIter).second.depth = currdepth.second;
+      }
+
+      methIter++;
+    }
+  }
+
+  readStartEndMap->clear();
+}
+
+MethylationGraph::MethylationGraph(ModCallParameters &in_params) {
+  params = &in_params;
+  nodeInfo = new std::map<int, std::map<std::string, VariantType>>;
+  edgeList = new std::map<int, VariantEdge *>;
+  forwardModNode = new std::map<int, ReadBaseMap *>;
+  reverseModNode = new std::map<int, ReadBaseMap *>;
+}
+
+MethylationGraph::~MethylationGraph() {}
+
+void MethylationGraph::addEdge(std::vector<ReadVariant> &in_readVariant,
+                               std::string chrName) {
+  readVariant = &in_readVariant;
+  int readCount = 0;
+  int vectorSize = 0;
+  // iter all read
+  for (std::vector<ReadVariant>::iterator readIter = in_readVariant.begin();
+       readIter != in_readVariant.end(); readIter++) {
+    ReadVariant tmpRead;
+    vectorSize += (*readIter).variantVec.size();
+    readCount++;
+
+    for (auto variant : (*readIter).variantVec) {
+      auto nodeIter = nodeInfo->find(variant.position);
+
+      if (nodeIter == nodeInfo->end()) {
+        (*nodeInfo)[variant.position] = std::map<std::string, VariantType>();
+      }
+      (*nodeInfo)[variant.position][(*readIter).read_name] = variant.type;
+    }
+
+    for (auto variant1Iter = (*readIter).variantVec.begin();
+         variant1Iter != (*readIter).variantVec.end(); ++variant1Iter) {
+      auto variant2Iter = std::next(variant1Iter);
+      int searchCount = 0;
+      while (variant2Iter != (*readIter).variantVec.end() && searchCount < 50) {
+        if (!(variant1Iter->type == VariantType::SNP &&
+              variant2Iter->type == VariantType::SNP)) {
+
+          int pos = variant1Iter->position;
+          auto edgeIter = edgeList->find(pos);
+          if (edgeIter == edgeList->end()) {
+            (*edgeList)[pos] = new VariantEdge(pos);
+          }
+
+          if (variant1Iter->allele == 0) {
+            (*edgeList)[pos]->ref->addSubEdge(variant1Iter->quality,
+                                              *variant2Iter,
+                                              readIter->read_name, 0, 1);
+          } else if (variant1Iter->allele == 1) {
+            (*edgeList)[pos]->alt->addSubEdge(variant1Iter->quality,
+                                              *variant2Iter,
+                                              readIter->read_name, 0, 1);
+          }
+        }
+        ++searchCount;
+        ++variant2Iter;
+      }
+    }
+  }
+}
+
+void MethylationGraph::connectResults(std::string chrName,
+                                      std::vector<int> &passPosition,
+                                      bool hasValidSnpData) {
+  std::set<int> strongMethylationPoints;
+  std::set<int> weakMethylationPoints;
+  std::set<int> addedPositions;
+  std::vector<int> prepassPosition;
+
+  if (!hasValidSnpData) {
+    collectAllModPoints(strongMethylationPoints);
+  } else {
+    collectStrongPoints(strongMethylationPoints, weakMethylationPoints,
+                        prepassPosition);
+  }
+
+  expandStrongPoints(strongMethylationPoints, prepassPosition,
+                     weakMethylationPoints, addedPositions, hasValidSnpData);
+  iterateWeakPoints(weakMethylationPoints, addedPositions, prepassPosition);
+  filterByNeighborConnection(prepassPosition, passPosition);
+}
+
+float MethylationGraph::computeMinConnection(int pos1, int pos2) const {
+  return std::max(((*nodeInfo)[pos1].size() + (*nodeInfo)[pos2].size()) / 4.0,
+                  6.0);
+}
+
+double MethylationGraph::computeMajorRatio(std::pair<int, int> counts) const {
+  return (double)std::max(counts.first, counts.second) /
+         (double)(counts.first + counts.second);
+}
+
+bool MethylationGraph::isGoodConnection(std::pair<int, int> counts,
+                                        float minConn) const {
+  int total = counts.first + counts.second;
+  return computeMajorRatio(counts) >= params->connectConfidence &&
+         total > minConn;
+}
+
+void MethylationGraph::collectAllModPoints(std::set<int> &strongPoints) {
+  for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end();
+       ++nodeIter) {
+    if (checkVariantType(nodeIter->first) == VariantType::MOD) {
+      strongPoints.insert(nodeIter->first);
+    }
+  }
+}
+
+void MethylationGraph::collectStrongPoints(std::set<int> &strongPoints,
+                                           std::set<int> &weakPoints,
+                                           std::vector<int> &prepass) {
+  std::vector<int> hasConnect;
+
+  for (auto nodeIter = nodeInfo->begin(); nodeIter != nodeInfo->end();
+       ++nodeIter) {
+    int currPos = nodeIter->first;
+    auto nextNodeIter = std::next(nodeIter, 1);
+    int searchCount = 0;
+    if (nextNodeIter == nodeInfo->end()) {
+      break;
+    }
+
+    auto edgeIter = edgeList->find(currPos);
+    if (edgeIter == edgeList->end())
+      continue;
+
+    if (checkVariantType(currPos) == VariantType::MOD) {
+      auto searchNodeIter = nextNodeIter;
+      while (searchNodeIter != nodeInfo->end() &&
+             searchCount < params->connectAdjacent) {
+        std::pair<int, int> tmp =
+            edgeIter->second->findNumberOfRead(searchNodeIter->first);
+        int totalConnectReads = tmp.first + tmp.second;
+        float minimumConnection =
+            computeMinConnection(currPos, searchNodeIter->first);
+        if (totalConnectReads <= minimumConnection) {
+          break;
+        }
+        if (checkVariantType(searchNodeIter->first) == VariantType::SNP) {
+          hasConnect.push_back(currPos);
+          if (isGoodConnection(tmp, minimumConnection) &&
+              strongPoints.count(currPos) == 0) {
+            strongPoints.insert(currPos);
+            break;
+          }
+        }
+        ++searchNodeIter;
+        ++searchCount;
+      }
+      if (std::find(hasConnect.begin(), hasConnect.end(), currPos) ==
+          hasConnect.end()) {
+        weakPoints.insert(currPos);
+      }
+    } else if (checkVariantType(currPos) == VariantType::SNP) {
+      auto searchNodeIter = nextNodeIter;
+      prepass.push_back(currPos);
+      while (searchNodeIter != nodeInfo->end()) {
+        std::pair<int, int> tmp =
+            edgeIter->second->findNumberOfRead(searchNodeIter->first);
+        int totalConnectReads = tmp.first + tmp.second;
+        float minimumConnection =
+            computeMinConnection(currPos, searchNodeIter->first);
+        if (totalConnectReads <= minimumConnection) {
+          break;
+        }
+        if (checkVariantType(searchNodeIter->first) == VariantType::MOD) {
+          hasConnect.push_back(searchNodeIter->first);
+          if (isGoodConnection(tmp, minimumConnection) &&
+              strongPoints.count(nextNodeIter->first) == 0) {
+            strongPoints.insert(nextNodeIter->first);
+          }
+        }
+        ++searchNodeIter;
+        ++searchCount;
+      }
+    }
+  }
+}
+
+void MethylationGraph::expandStrongPoints(const std::set<int> &strongPoints,
+                                          std::vector<int> &prepass,
+                                          std::set<int> &weakPoints,
+                                          std::set<int> &addedPositions,
+                                          bool hasValidSnpData) {
+  for (auto it1 = strongPoints.begin(); it1 != strongPoints.end(); ++it1) {
+    int pos1 = *it1;
+    auto it2 = std::next(it1, 1);
+    auto searchNodeIter = it2;
+    int searchCount = 0;
+    auto edgeIter = edgeList->find(pos1);
+    if (edgeIter == edgeList->end())
+      continue;
+
+    while (searchNodeIter != strongPoints.end() &&
+           searchCount < params->connectAdjacent) {
+      int pos2 = *searchNodeIter;
+      std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos2);
+      int totalConnectReads = tmp.first + tmp.second;
+      float minimumConnection = computeMinConnection(pos1, pos2);
+
+      if (totalConnectReads <= minimumConnection) {
+        break;
+      }
+
+      if (isGoodConnection(tmp, minimumConnection)) {
+        if (addedPositions.count(pos1) == 0) {
+          prepass.push_back(pos1);
+          addedPositions.insert(pos1);
+          // Only add positions to weakMethylationPoints if there is valid SNP
+          // data (for third pass)
+          if (hasValidSnpData) {
+            weakPoints.insert(pos1);
+          }
+        }
+        if (addedPositions.count(pos2) == 0) {
+          prepass.push_back(pos2);
+          addedPositions.insert(pos2);
+          // Only add positions to weakMethylationPoints if there is valid SNP
+          // data (for third pass)
+          if (hasValidSnpData) {
+            weakPoints.insert(pos2);
+          }
+        }
+      }
+      ++searchNodeIter;
+      ++searchCount;
+    }
+  }
+}
+
+void MethylationGraph::iterateWeakPoints(std::set<int> &weakPoints,
+                                         std::set<int> &addedPositions,
+                                         std::vector<int> &prepass) {
+  std::set<int> weakPoints2;
+  std::set<int> addedPositions2;
+
+  // third pass: evaluate connections between weak methylation points
+  for (int i = 0; i < params->iterCount; i++) {
+    // Use alternating sets for each iteration
+    auto &currentWeakPoints = (i % 2 == 0) ? weakPoints : weakPoints2;
+    auto &nextWeakPoints = (i % 2 == 0) ? weakPoints2 : weakPoints;
+    auto &currentAddedPositions =
+        (i % 2 == 0) ? addedPositions : addedPositions2;
+    auto &nextAddedPositions = (i % 2 == 0) ? addedPositions2 : addedPositions;
+
+    // Clear the target set for this iteration
+    nextWeakPoints.clear();
+    nextAddedPositions.clear();
+
+    for (auto it1 = currentWeakPoints.begin(); it1 != currentWeakPoints.end();
+         ++it1) {
+      int currPos = *it1;
+      auto nextIter = it1;
+      int nextSearchCount = 0;
+      bool isAdded = false;
+      auto edgeIter = edgeList->find(currPos);
+      if (edgeIter == edgeList->end())
+        continue;
+      while (++nextIter != currentWeakPoints.end() &&
+             nextSearchCount < params->connectAdjacent) {
+        int nextPos = *nextIter;
+        if (currentAddedPositions.count(nextPos) == 0 &&
+            currentAddedPositions.count(currPos) == 0) {
+          ++nextSearchCount;
+          continue;
+        }
+        isAdded = true;
+        std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
+        int totalConnectReads = tmp.first + tmp.second;
+        float minimumConnection = computeMinConnection(currPos, nextPos);
+        if (totalConnectReads <= minimumConnection) {
+          break;
+        }
+        if (isGoodConnection(tmp, minimumConnection)) {
+          if (std::find(prepass.begin(), prepass.end(), currPos) ==
+              prepass.end()) {
+            prepass.push_back(currPos);
+            nextWeakPoints.insert(currPos);
+            nextAddedPositions.insert(currPos);
+          }
+          if (std::find(prepass.begin(), prepass.end(), nextPos) ==
+              prepass.end()) {
+            prepass.push_back(nextPos);
+            nextWeakPoints.insert(nextPos);
+            nextAddedPositions.insert(nextPos);
+          }
+        }
+        ++nextSearchCount;
+      }
+      if (!isAdded) {
+        nextWeakPoints.insert(currPos);
+      }
+    }
+  }
+}
+
+void MethylationGraph::filterByNeighborConnection(
+    std::vector<int> &prepass, std::vector<int> &passPosition) {
+  // Ensure passPosition is sorted by position
+  std::sort(prepass.begin(), prepass.end());
+  // Fourth step: Filter positions that do not have good connections to both
+  // neighbors
+  for (size_t i = 0; i < prepass.size(); ++i) {
+    int pos = prepass[i];
+    bool hasGoodPrevConnection = false;
+    bool hasGoodNextConnection = false;
+    if (nodeInfo->find(pos) != nodeInfo->end()) {
+      if (checkVariantType(pos) == VariantType::SNP) {
+        continue;
+      }
+    }
+
+    // Check connection with previous position
+    if (i > 0) {
+      int prevPos = prepass[i - 1];
+      auto edgeIter = edgeList->find(prevPos);
+      if (edgeIter == edgeList->end()) {
+        hasGoodPrevConnection = true;
+        continue;
+      }
+      std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(pos);
+      int totalConnectReads = tmp.first + tmp.second;
+      double majorRatio = computeMajorRatio(tmp);
+      if (totalConnectReads != 0) {
+
+        if (majorRatio >= params->connectConfidence && totalConnectReads >= 6) {
+          hasGoodPrevConnection = true;
+        }
+      }
+    }
+
+    // Check connection with next position
+    if (i < prepass.size() - 1 && hasGoodPrevConnection) {
+      int nextPos = prepass[i + 1];
+      auto edgeIter = edgeList->find(pos);
+      if (edgeIter == edgeList->end()) {
+        hasGoodNextConnection = true;
+        continue;
+      }
+      std::pair<int, int> tmp = edgeIter->second->findNumberOfRead(nextPos);
+      int totalConnectReads = tmp.first + tmp.second;
+      double majorRatio = computeMajorRatio(tmp);
+      if (totalConnectReads != 0) {
+        if (majorRatio >= params->connectConfidence && totalConnectReads >= 6) {
+          hasGoodNextConnection = true;
+        }
+      }
+    }
+
+    // Only keep positions with good connections to both neighbors (or edge
+    // positions)
+    if (hasGoodNextConnection || i == 0 || i == prepass.size() - 1) {
+      passPosition.push_back(pos);
+    }
+  }
+  prepass.clear();
+}
+
+int MethylationGraph::checkVariantType(int position) {
+  auto nodeIter = nodeInfo->find(position);
+  if (nodeIter != nodeInfo->end()) {
+    for (const auto &nodeType : nodeIter->second) {
+      if (nodeType.second == VariantType::MOD) {
+        return VariantType::MOD; // Return true if any type is MOD
+      } else if (nodeType.second == VariantType::SNP) {
+        return VariantType::SNP; // Return true if any type is SNP
+      } else if (nodeType.second == VariantType::INDEL) {
+        return VariantType::INDEL; // Return true if any type is INDEL
+      } else if (nodeType.second == VariantType::SV) {
+        return VariantType::SV; // Return true if any type is SV
+      } else {
+        return -1; // Return -1 if no variant type is found
+      }
+    }
+  }
+  return -1; // Return -1 if the position is not in the nodeInfo
+}
+
+void MethylationGraph::destroy() {
+
+  for (auto edgeIter = edgeList->begin(); edgeIter != edgeList->end();
+       edgeIter++) {
+    edgeIter->second->ref->destroy();
+    edgeIter->second->alt->destroy();
+    delete edgeIter->second->ref;
+    delete edgeIter->second->alt;
+  }
+
+  for (auto nodeIter = forwardModNode->begin();
+       nodeIter != forwardModNode->end(); nodeIter++) {
+    delete nodeIter->second;
+  }
+
+  for (auto nodeIter = reverseModNode->begin();
+       nodeIter != reverseModNode->end(); nodeIter++) {
+    delete nodeIter->second;
+  }
+
+  delete nodeInfo;
+  delete edgeList;
+}
+
+MethSnpParser::MethSnpParser(ModCallParameters &in_params)
+    : hasSnpData(false) {
+  chrVariant = new std::map<std::string, std::map<int, SnpVariant>>;
+  params = &in_params;
+
+  if (params->snpFile.empty()) {
+    std::cerr << "No SNP file provided, running without SNP variants.";
+    return;
+  }
+
+  hasSnpData = loadSNPVCF();
+}
+
+bool MethSnpParser::loadSNPVCF() {
+  htsFile *inf = bcf_open(params->snpFile.c_str(), "r");
+  if (inf == nullptr) {
+    std::cerr << "Warning: Could not open SNP file " << params->snpFile
+              << ", running without SNP variants.";
+    return false;
+  }
+
+  bcf_hdr_t *hdr = bcf_hdr_read(inf);
+  if (hdr == nullptr) {
+    std::cerr << "Warning: Could not read SNP file header, running without SNP "
+                 "variants.";
     bcf_close(inf);
-    
-    // Set successful loading flag
-    hasSnpData = true;
-    std::cerr << "Successfully loaded SNP variants from " << params->snpFile << "\n";
-}
+    return false;
+  }
 
-void MethSnpParser::parserProcess(std::string &input) {
-}
+  int nseq = 0;
+  const char **seqnames = bcf_hdr_seqnames(hdr, &nseq);
 
-MethSnpParser::~MethSnpParser() {
-    delete chrVariant;
-}
+  std::string allSmples = "-";
+  int is_file = bcf_hdr_set_samples(hdr, allSmples.c_str(), 0);
+  if (is_file != 0) {
+    std::cout << "error or a positive integer if the list contains samples not "
+                 "present in the VCF header\n";
+  }
 
-bool MethSnpParser::hasValidSnpData() const {
-    return hasSnpData;
-}
+  bcf1_t *rec = bcf_init();
+  int ngt_arr = 0;
+  int ngt = 0;
+  int *gt = NULL;
 
+  while (bcf_read(inf, hdr, rec) == 0) {
+    if (bcf_is_snp(rec)) {
+      ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
 
-void MethSnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult) {
-    //header
-    if( input.substr(0, 2) == "##" ){
-        // avoid double definition
-        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
-            ps_def = true;
+      if (ngt < 0) {
+        std::cerr << "pos " << rec->pos << " missing GT value" << "\n";
+        exit(1);
+      }
+
+      if ((gt[0] == 2 && gt[1] == 4) || // 0/1
+          (gt[0] == 4 && gt[1] == 2) || // 1/0
+          (gt[0] == 2 && gt[1] == 5) || // 0|1
+          (gt[0] == 4 && gt[1] == 3)    // 1|0
+      ) {
+        std::string chr = seqnames[rec->rid];
+        int variantPos = rec->pos;
+        SnpVariant tmp;
+        tmp.Ref = rec->d.allele[0];
+        tmp.Alt = rec->d.allele[1];
+
+        if (rec->d.allele[1][2] != '\0') {
+          continue;
         }
-        resultVcf << input << "\n";
+
+        (*chrVariant)[chr][variantPos] = tmp;
+      }
     }
-    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
-        // format line 
-        if( commandLine == false ){
-            if(ps_def == false){
-                resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
-                ps_def = true;
-            }
-            resultVcf << "##longphaseVersion=" << params->version << "\n";
-            resultVcf << "##commandline=\"" << params->command << "\"\n";
-            commandLine = true;
-        }
-        resultVcf << input << "\n";
-    }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+  }
 
-        if( fields.size() == 0 )
-            return;
+  if (gt)
+    free(gt);
+  bcf_destroy(rec);
+  bcf_hdr_destroy(hdr);
+  bcf_close(inf);
 
-        int pos = std::stoi( fields[1] );
-        int posIdx = pos - 1 ;
-        std::string key = fields[0] + "_" + std::to_string(posIdx);
-
-        PhasingResult::iterator psElementIter =  phasingResult.find(key);
-
-        // PS flag already exist, erase PS info
-        if( fields[8].find("PS")!= std::string::npos ){
-
-            // find PS flag
-            int colon_pos = 0;
-            int ps_pos = fields[8].find("PS");
-            for(int i =0 ; i< ps_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-                                
-            // erase PS flag
-            if( fields[8].find(":",ps_pos+1) != std::string::npos ){
-                fields[8].erase(ps_pos, 3);
-            }
-            else{
-                fields[8].erase(ps_pos - 1, 3);
-            }
-                            
-            // find PS value start
-            int current_colon = 0;
-            int ps_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                ps_start++;
-            }
-                            
-            // erase PS value
-            if( fields[9].find(":",ps_start+1) != std::string::npos ){
-                int ps_end_pos = fields[9].find(":",ps_start+1);
-                fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
-            }
-            else{
-                fields[9].erase(ps_start-1, fields[9].length() - ps_start + 1);
-            }
-        }
-        // reset GT flag
-        if( fields[8].find("GT")!= std::string::npos ){
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            if(fields[9][modify_start+1] == '|'){
-                // direct modify GT value
-                if(fields[9][modify_start] > fields[9][modify_start+2]){
-                    fields[9][modify_start+1] = fields[9][modify_start];
-                    fields[9][modify_start] = fields[9][modify_start+2];
-                    fields[9][modify_start+2] =fields[9][modify_start+1];
-                }
-                fields[9][modify_start+1] = '/';
-            }   
-        }
-
-        // Check if the variant is extracted from this VCF
-        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
-        
-        // this pos is phase
-        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
-                        
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-                }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            // direct modify GT value
-            fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
-            fields[9][modify_start+1] = '|';
-            fields[9][modify_start+2] = (*psElementIter).second.RAstatus[2];
-        }
-        // this pos has not been phased
-        else{
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":.";
-        }
-                    
-        for(std::vector<std::string>::iterator fieldIter = fields.begin(); fieldIter != fields.end(); ++fieldIter){
-            if( fieldIter != fields.begin() )
-                resultVcf<< "\t";
-            resultVcf << (*fieldIter);
-        }
-        resultVcf << "\n";
-    }
+  std::cerr << "Successfully loaded SNP variants from " << params->snpFile
+            << "\n";
+  return true;
 }
 
-std::map<int, RefAlt> MethSnpParser::getVariants(std::string chrName) {
-    std::map<int, RefAlt> targetVariants;
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
-    
-    if( chrIter != chrVariant->end() )
-        targetVariants = (*chrIter).second;
-    
-    return targetVariants;
-}
+void MethSnpParser::parserProcess(std::string &input) {}
 
-std::map<int, RefAlt> MethSnpParser::getVariants_markindel(std::string chrName, const std::string &ref) {
-    std::map<int, RefAlt> targetVariants;
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
+MethSnpParser::~MethSnpParser() { delete chrVariant; }
 
-    //Mark the indel which lies in the tandem repeat
-    if (chrIter != chrVariant->end()) {
-        // Accessing the inner map using chrIter->second and iterating over it
-        for ( auto innerIter = chrIter->second.begin(); innerIter != chrIter->second.end(); innerIter++ ) {
-            int variant_pos = innerIter->first;      // Accessing the variant_pos of the inner map
-            RefAlt variant_info = innerIter->second; // Accessing the variant_info of the inner map
-            int ref_pos = variant_pos ;
-	        bool danger = false ;
+bool MethSnpParser::hasValidSnpData() const { return hasSnpData; }
 
-            std::string repeat = ref.substr(ref_pos + 1, 2) ; // get the 2 words string in the reference which behind the indel position
-            int i = 0 ;
-	        //check if there has 2 words tandem repeat in the reference
-            while ( i < 5 && (variant_info.Ref.length()>1 ||variant_info.Alt.length()>1) /*&& repeat[0]!=repeat[1]*/ ) {
-                if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2] ) {
-                    break ;
-                }
+void MethSnpParser::writeDataLine(const std::string &input,
+                                  std::ofstream &resultVcf,
+                                  PhasingResult &phasingResult) {
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
 
-                ref_pos = ref_pos + 2 ;
-                i++ ;
-            }
+  if (fields.size() == 0)
+    return;
 
-	    // set the dnager to true if the repeat word repeats at least five times
-	    if ( i == 5 ) danger = true ;
+  int pos = std::stoi(fields[1]);
+  int posIdx = pos - 1;
+  std::string key = fields[0] + "_" + std::to_string(posIdx);
 
-            innerIter->second.is_danger = danger ;
+  PhasingResult::iterator psElementIter = phasingResult.find(key);
 
-        }
+  // PS flag already exist, erase PS info
+  if (fields[8].find("PS") != std::string::npos) {
+    std::string format_before_ps_erase = fields[8];
+    int ps_pos = fields[8].find("PS");
 
-        targetVariants = (*chrIter).second;
-    }
-    else {
-        // Handle the case where chrName doesn't exist in chrVariant
+    // erase PS flag
+    if (fields[8].find(":", ps_pos + 1) != std::string::npos) {
+      fields[8].erase(ps_pos, 3);
+    } else {
+      fields[8].erase(ps_pos - 1, 3);
     }
 
-    return targetVariants;
+    int ps_start = findFieldValueStart(format_before_ps_erase, fields[9], "PS");
+
+    // erase PS value
+    if (fields[9].find(":", ps_start + 1) != std::string::npos) {
+      int ps_end_pos = fields[9].find(":", ps_start + 1);
+      fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
+    } else {
+      fields[9].erase(ps_start - 1, fields[9].length() - ps_start + 1);
+    }
+  }
+
+  // reset GT flag
+  if (fields[8].find("GT") != std::string::npos) {
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    if (fields[9][modify_start + 1] == '|') {
+      if (fields[9][modify_start] > fields[9][modify_start + 2]) {
+        fields[9][modify_start + 1] = fields[9][modify_start];
+        fields[9][modify_start] = fields[9][modify_start + 2];
+        fields[9][modify_start + 2] = fields[9][modify_start + 1];
+      }
+      fields[9][modify_start + 1] = '/';
+    }
+  }
+
+  // Check if the variant is extracted from this VCF
+  auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+
+  // this pos is phased
+  if (psElementIter != phasingResult.end() &&
+      posIter != (*chrVariant)[fields[0]].end()) {
+    fields[8] = fields[8] + ":PS";
+    fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
+
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
+    fields[9][modify_start + 1] = '|';
+    fields[9][modify_start + 2] = (*psElementIter).second.RAstatus[2];
+  } else {
+    fields[8] = fields[8] + ":PS";
+    fields[9] = fields[9] + ":.";
+  }
+
+  for (std::vector<std::string>::iterator fieldIter = fields.begin();
+       fieldIter != fields.end(); ++fieldIter) {
+    if (fieldIter != fields.begin())
+      resultVcf << "\t";
+    resultVcf << (*fieldIter);
+  }
+  resultVcf << "\n";
 }
 
-std::vector<std::string> MethSnpParser::getChrVec() {
-    return chrName;
-}
+std::map<int, SnpVariant>
+MethSnpParser::getVariants_markindel(std::string chrName,
+                                     const std::string &ref) {
+  std::map<int, SnpVariant> targetVariants;
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrIter =
+      chrVariant->find(chrName);
 
-int MethSnpParser::getLastSNP(std::string chrName) {
-    std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
-    // this chromosome not exist in this file. 
-    if(chrVariantIter == chrVariant->end())
-        return -1;
-    // get last SNP
-    std::map< int, RefAlt >::reverse_iterator lastVariantIter = (*chrVariantIter).second.rbegin();
-    // there are no SNPs on this chromosome
-    if(lastVariantIter == (*chrVariantIter).second.rend())
-        return -1;
-    return (*lastVariantIter).first;
+  if (chrIter != chrVariant->end()) {
+    for (auto innerIter = chrIter->second.begin();
+         innerIter != chrIter->second.end(); ++innerIter) {
+      innerIter->second.is_danger = isDangerIndel(
+          innerIter->first, ref, innerIter->second.Ref.length(),
+          innerIter->second.Alt.length());
+    }
+    targetVariants = chrIter->second;
+  }
+
+  return targetVariants;
 }
 
 void MethSnpParser::writeResult(PhasingResult phasingResult) {
-    if( params->snpFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
-    }
-    else if( params->snpFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
-    }
-    return;
+  dispatchWriteResult(params->snpFile, params->resultPrefix + ".vcf",
+                      phasingResult);
 }

--- a/ModCallParsingBam.h
+++ b/ModCallParsingBam.h
@@ -1,157 +1,207 @@
 #ifndef MODCALLPARSINGBAM_H
 #define MODCALLPARSINGBAM_H
 
-#include "Util.h"
 #include "ModCallProcess.h"
-#include <htslib/sam.h>
-#include <htslib/faidx.h>
-#include <htslib/khash.h>
-#include <htslib/kbitset.h>
-#include <htslib/thread_pool.h>
-#include <htslib/vcf.h>
-#include <htslib/vcfutils.h>
-#include <htslib/kstring.h>
 #include "ParsingBam.h"
 #include "PhasingGraph.h"
 #include "PhasingProcess.h"
+#include "Util.h"
+#include <htslib/faidx.h>
+#include <htslib/kbitset.h>
+#include <htslib/khash.h>
+#include <htslib/kstring.h>
+#include <htslib/sam.h>
+#include <htslib/thread_pool.h>
+#include <htslib/vcf.h>
+#include <htslib/vcfutils.h>
 
+struct MethPosInfo {
+  MethPosInfo()
+      : methreadcnt(0), noisereadcnt(0), canonreadcnt(0), depth(0),
+        heterstatus(""), strand(-1), variantType(VariantType::MOD) {}
 
-struct MethPosInfo{
-    MethPosInfo():methreadcnt(0), noisereadcnt(0),canonreadcnt(0), depth(0),heterstatus(""),strand(-1),variantType(VariantType::MOD){}
-
-    int methreadcnt;
-    int noisereadcnt;
-    int canonreadcnt;
-    int depth;
-    std::string heterstatus;
-    int strand; //0: + , 1: -
-    VariantType variantType;
-    std::vector<std::string> modReadVec;
-    std::vector<std::string> nonModReadVec;
+  int methreadcnt;
+  int noisereadcnt;
+  int canonreadcnt;
+  int depth;
+  std::string heterstatus;
+  int strand; // 0: + , 1: -
+  VariantType variantType;
+  std::vector<std::string> modReadVec;
+  std::vector<std::string> nonModReadVec;
 };
 
-// The ReferenceChromosome struct is used to store information about a reference fasta.
+// The ReferenceChromosome struct is used to store information about a reference
+// fasta.
 struct ReferenceChromosome {
-    std::string name;      
-    std::string sequence;  
-    int length;            
+  std::string name;
+  std::string sequence;
+  int length;
 
-    ReferenceChromosome(const std::string& name, const std::string& sequence, int length)
-        : name(name), sequence(sequence), length(length) {}
+  ReferenceChromosome(const std::string &name, const std::string &sequence,
+                      int length)
+      : name(name), sequence(sequence), length(length) {}
 };
 
-//FastaParser: to get each chromosome name and lastpos(for chunksize)
-class MethFastaParser{
-    private:
-        // file name
-        std::string fastaFile ;
+// FastaParser: to get each chromosome name and lastpos(for chunksize)
+class MethFastaParser {
+private:
+  // file name
+  std::string fastaFile;
 
-    public:
-        MethFastaParser(std::string fastaFile, std::vector<ReferenceChromosome> &chrInfo);
-        ~MethFastaParser();
+public:
+  MethFastaParser(std::string fastaFile,
+                  std::vector<ReferenceChromosome> &chrInfo);
+  ~MethFastaParser();
 };
 
-struct MethPosProb{
-    MethPosProb(int position, int prob):
-    position(position),
-    prob(prob){};
-    
-    int position;
-    int prob;
+struct MethPosProb {
+  MethPosProb(int position, int prob) : position(position), prob(prob) {};
+
+  int position;
+  int prob;
 };
 
-struct AlignmentMethExtend: Alignment{    
-    //hts_base_mod_state *m;
-    //store the read position and probability
-    std::vector<MethPosProb> queryMethVec;
+struct AlignmentMethExtend : Alignment {
+  // hts_base_mod_state *m;
+  // store the read position and probability
+  std::vector<MethPosProb> queryMethVec;
 };
 
 class MethSnpParser : public BaseVairantParser {
 private:
-    ModCallParameters *params;  // Use ModCallParameters instead
-    //std::map<std::string, std::map<int, RefAlt>> *chrVariant;
-    std::vector<std::string> chrName;
-    std::map<std::string, std::map<int, bool>> chrVariantHomopolymer;
-    bool commandLine;
-    bool hasSnpData;  // indicate if the SNP data is loaded successfully
+  ModCallParameters *params; // Use ModCallParameters instead
+  // std::map<std::string, std::map<int, SnpVariant>> *chrVariant;
+  bool hasSnpData; // indicate if the SNP data is loaded successfully
 
-    void parserProcess(std::string &input);
-    void writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult);
+  bool loadSNPVCF();
+  void parserProcess(std::string &input);
+  void writeDataLine(const std::string &input, std::ofstream &resultVcf,
+                     PhasingResult &phasingResult);
 
 public:
-    MethSnpParser(ModCallParameters &in_params);  // New constructor
-    ~MethSnpParser();
+  MethSnpParser(ModCallParameters &in_params); // New constructor
+  ~MethSnpParser();
 
-    std::map<std::string, std::map<int, RefAlt>> *chrVariant;
+  std::map<std::string, std::map<int, SnpVariant>> *chrVariant;
 
-    std::map<int, RefAlt> getVariants(std::string chrName);
-    std::map<int, RefAlt> getVariants_markindel(std::string chrName, const std::string &ref);
-    std::vector<std::string> getChrVec();
-    int getLastSNP(std::string chrName);
-    void writeResult(PhasingResult phasingResult);
-    bool hasValidSnpData() const;  // check if the SNP data is loaded successfully
+  std::map<int, SnpVariant> getVariants_markindel(std::string chrName,
+                                              const std::string &ref);
+  void writeResult(PhasingResult phasingResult);
+  bool hasValidSnpData() const; // check if the SNP data is loaded successfully
 };
 
-class MethBamParser{
-    private:
-        ModCallParameters *params;
-        std::string *refString;
-        std::string chrName;
-        int refstartpos;
-        
-        std::map<int , MethPosInfo> *chrMethMap;
-        //<pos, <positive strand cnt, negative strand cnt>>
-        std::map<int, std::pair<int,int>> *readStartEndMap; 
-        
-        // get methylation tag from BAM file
-        std::string get_aux_tag(const bam1_t *aln, const char tag[2]);
-        void parse_CIGAR(const  bam_hdr_t &bamHdr,const bam1_t &aln, std::vector<ReadVariant> &readVariantVec);
-        
-        // record methylation position and probability from methylation tag
-        void getmeth(AlignmentMethExtend &align);
-        std::map<int, RefAlt> *currentVariants;
-        std::map<int, RefAlt>::iterator firstVariantIter;
-        
-    public:
-        MethBamParser(std::string inputChrName, ModCallParameters &in_params, MethSnpParser &snpMap, std::string &ref_string);
-        ~MethBamParser();
-        void detectMeth(std::string chrName, int lastSNPPos, htsThreadPool &threadPool, std::vector<ReadVariant> &readVariantVec);
-        void calculateDepth();
-        void exportResult(std::string chrName, std::string chrSquence, int chrLen, std::vector<int> &passPosition, std::ostringstream &modCallResult);
-        void judgeMethGenotype(std::string chrName, std::vector<ReadVariant> &readVariantVec, std::vector<ReadVariant> &modReadVariantVec);
+class MethBamParser {
+private:
+  ModCallParameters *params;
+  std::string *refString;
+  std::string chrName;
+  int refstartpos;
+
+  std::map<int, MethPosInfo> *chrMethMap;
+  //<pos, <positive strand cnt, negative strand cnt>>
+  std::map<int, std::pair<int, int>> *readStartEndMap;
+
+  // get methylation tag from BAM file
+  std::string get_aux_tag(const bam1_t *aln, const char tag[2]);
+  bool isValidAlignment(const bam1_t *aln) const;
+  bool extractSnpAllele(
+      std::map<int, SnpVariant>::iterator &currentVariantIter, int ref_pos,
+      int length, int querypos, int cigaridx, int aln_core_n_cigar,
+      const uint32_t *cigar, const bam1_t &aln, ReadVariant *tmpReadResult);
+  void classifyMethylationBase(int &n, int &pos, hts_base_mod *mods,
+                               int querypos, int length, int refpos,
+                               const bam1_t &aln, ReadVariant *tmpReadResult,
+                               hts_base_mod_state *mod_state);
+  bool handleDeletionInHomopolymer(
+      std::map<int, SnpVariant>::iterator &currentVariantIter, int ref_pos,
+      int length, int querypos, const bam1_t &aln,
+      hts_base_mod_state *mod_state, ReadVariant *tmpReadResult);
+  void updateDepthBoundary(int refstart, int refpos, bool is_reverse);
+  void computeSinglePositionGenotype();
+  std::set<int> applyCpGStrandPairGenotype();
+  void filterModReadVariants(const std::set<int> &positionPairs,
+                             std::vector<ReadVariant> &readVariantVec,
+                             std::vector<ReadVariant> &modReadVariantVec);
+  std::string buildInfoStr(const MethPosInfo &info) const;
+  std::string formatMethVcfLine(int pos, const MethPosInfo &info,
+                                const std::string &chrSequence,
+                                int chrLen) const;
+  void parse_CIGAR(const bam_hdr_t &bamHdr, const bam1_t &aln,
+                   std::vector<ReadVariant> &readVariantVec);
+
+  // record methylation position and probability from methylation tag
+  void getmeth(AlignmentMethExtend &align);
+  std::map<int, SnpVariant> *currentVariants;
+  std::map<int, SnpVariant>::iterator firstVariantIter;
+
+public:
+  MethBamParser(std::string inputChrName, ModCallParameters &in_params,
+                MethSnpParser &snpMap, std::string &ref_string);
+  ~MethBamParser();
+  void detectMeth(std::string chrName, int lastSNPPos,
+                  htsThreadPool &threadPool,
+                  std::vector<ReadVariant> &readVariantVec);
+  void dumpMethMap(const std::string &chrName, std::ofstream &out) const;
+  void dumpReadStartEnd(const std::string &chrName, std::ofstream &out) const;
+  void calculateDepth();
+  void exportResult(std::string chrName, std::string chrSquence, int chrLen,
+                    std::vector<int> &passPosition,
+                    std::ostringstream &modCallResult);
+  void judgeMethGenotype(std::string chrName,
+                         std::vector<ReadVariant> &readVariantVec,
+                         std::vector<ReadVariant> &modReadVariantVec);
+  void dumpMethGenoMap(const std::string &chrName, std::ofstream &out) const;
 };
 
-void writeResultVCF(ModCallParameters &params, std::vector<ReferenceChromosome> &chrInfo, std::map<std::string,std::ostringstream> &chrResult);
+void writeResultVCF(ModCallParameters &params,
+                    std::vector<ReferenceChromosome> &chrInfo,
+                    std::map<std::string, std::ostringstream> &chrResult);
 
-class MethylationGraph{
-    private:
-        ModCallParameters *params;
-        std::vector<ReadVariant> *readVariant;
-        
-        // modifications
-        // position, quality
-        std::map<int,ReadBaseMap*> *forwardModNode;
-        std::map<int,ReadBaseMap*> *reverseModNode;
-        
-        // By default, a Map in C++ is sorted in increasing order based on its key.
-        // position, edge
-        std::map<int,VariantEdge*> *edgeList;
-        // record all variant position, include SNP and SV 
-        // <position, <readID, VariantType>>
-        std::map<int, std::map<std::string, VariantType>> *nodeInfo;
-        // check the variant type of the position
-        int checkVariantType(int position);
-        //store strong methylation position
-        std::set<int> strongMethylationPoints;
-        
-    public:
-    
-        MethylationGraph(ModCallParameters &params);
-        ~MethylationGraph();
-        
-        void addEdge(std::vector<ReadVariant> &in_readVariant, std::string chrName);
-        void connectResults(std::string chrName, std::vector<int> &passPosition, bool hasValidSnpData = true);
-        void destroy();
+class MethylationGraph {
+private:
+  ModCallParameters *params;
+  std::vector<ReadVariant> *readVariant;
+
+  // modifications
+  // position, quality
+  std::map<int, ReadBaseMap *> *forwardModNode;
+  std::map<int, ReadBaseMap *> *reverseModNode;
+
+  // By default, a Map in C++ is sorted in increasing order based on its key.
+  // position, edge
+  std::map<int, VariantEdge *> *edgeList;
+  // record all variant position, include SNP and SV
+  // <position, <readID, VariantType>>
+  std::map<int, std::map<std::string, VariantType>> *nodeInfo;
+  // check the variant type of the position
+  int checkVariantType(int position);
+  float computeMinConnection(int pos1, int pos2) const;
+  double computeMajorRatio(std::pair<int, int> counts) const;
+  bool isGoodConnection(std::pair<int, int> counts, float minConn) const;
+  void collectAllModPoints(std::set<int> &strongPoints);
+  void collectStrongPoints(std::set<int> &strongPoints,
+                           std::set<int> &weakPoints,
+                           std::vector<int> &prepass);
+  void expandStrongPoints(const std::set<int> &strongPoints,
+                          std::vector<int> &prepass,
+                          std::set<int> &weakPoints,
+                          std::set<int> &addedPositions,
+                          bool hasValidSnpData);
+  void iterateWeakPoints(std::set<int> &weakPoints,
+                         std::set<int> &addedPositions,
+                         std::vector<int> &prepass);
+  void filterByNeighborConnection(std::vector<int> &prepass,
+                                  std::vector<int> &passPosition);
+
+public:
+  MethylationGraph(ModCallParameters &params);
+  ~MethylationGraph();
+
+  void addEdge(std::vector<ReadVariant> &in_readVariant, std::string chrName);
+  void connectResults(std::string chrName, std::vector<int> &passPosition,
+                      bool hasValidSnpData = true);
+  void destroy();
 };
 
 #endif

--- a/ModCallProcess.cpp
+++ b/ModCallProcess.cpp
@@ -1,87 +1,151 @@
 #include "ModCallProcess.h"
 #include "ModCallParsingBam.h"
+#if defined(VALIDATE_PARSECG) || defined(VALIDATE_EXPORT) || \
+    defined(VALIDATE_PARSECG_DEPTH) || defined(VALIDATE_JMG)
+#include <fstream>
+#endif
+
+static MethBamParser* runBamPipeline(
+    const std::string &chrName,
+    std::string &chrSeq,
+    int chrLen,
+    ModCallParameters &params,
+    htsThreadPool &threadPool,
+    MethSnpParser &snpFile,
+    std::vector<ReadVariant> &readVariantVec,
+    std::vector<ReadVariant> &modReadVariantVec)
+{
+    MethBamParser *methbamparser = new MethBamParser(chrName, params, snpFile, chrSeq);
+    methbamparser->detectMeth(chrName, chrLen, threadPool, readVariantVec);
+#ifdef VALIDATE_PARSECG_DEPTH
+    #pragma omp critical (validate_parsecg_depth_dump)
+    {
+        std::ofstream depthout(params.resultPrefix + "_parsecg_depth.tsv", std::ios::app);
+        methbamparser->dumpReadStartEnd(chrName, depthout);
+    }
+#endif
+#ifdef VALIDATE_PARSECG
+    #pragma omp critical (validate_parsecg_dump)
+    {
+        std::ofstream methout(params.resultPrefix + "_parsecg_methmap.tsv", std::ios::app);
+        methbamparser->dumpMethMap(chrName, methout);
+
+        std::ofstream readout(params.resultPrefix + "_parsecg_readvar.tsv", std::ios::app);
+        for (const auto &rv : readVariantVec) {
+            for (const auto &v : rv.variantVec) {
+                readout << chrName
+                        << "\t" << rv.read_name
+                        << "\t" << rv.is_reverse
+                        << "\t" << rv.reference_start
+                        << "\t" << v.position
+                        << "\t" << v.allele
+                        << "\t" << v.quality
+                        << "\t" << static_cast<int>(v.type)
+                        << "\n";
+            }
+        }
+    }
+#endif
+    methbamparser->calculateDepth();
+    methbamparser->judgeMethGenotype(chrName, readVariantVec, modReadVariantVec);
+#ifdef VALIDATE_JMG
+    #pragma omp critical (validate_jmg_dump)
+    {
+        std::ofstream genomapout(params.resultPrefix + "_jmg_genomap.tsv", std::ios::app);
+        methbamparser->dumpMethGenoMap(chrName, genomapout);
+    }
+#endif
+    return methbamparser;
+}
+
+static void runGraphPipeline(
+    const std::string &chrName,
+    ModCallParameters &params,
+    std::vector<ReadVariant> &modReadVariantVec,
+    std::vector<int> &passPosition,
+    MethSnpParser &snpFile)
+{
+    MethylationGraph *modGraph = new MethylationGraph(params);
+    modGraph->addEdge(modReadVariantVec, chrName);
+    modGraph->connectResults(chrName, passPosition, snpFile.hasValidSnpData());
+    modGraph->destroy();
+    delete modGraph;
+}
+
+static void processChromosome(
+    const ReferenceChromosome &chr,
+    ModCallParameters &params,
+    htsThreadPool &threadPool,
+    MethSnpParser &snpFile,
+    std::ostringstream &result)
+{
+    std::time_t chrbegin = time(NULL);
+
+    std::vector<ReadVariant> readVariantVec;
+    std::vector<ReadVariant> modReadVariantVec;
+    std::vector<int> passPosition;
+
+    std::string chrName = chr.name;
+    std::string chrSeq  = chr.sequence;
+    int chrLen          = chr.length;
+
+    MethBamParser *methbamparser = runBamPipeline(chrName, chrSeq, chrLen, params, threadPool, snpFile, readVariantVec, modReadVariantVec);
+    runGraphPipeline(chrName, params, modReadVariantVec, passPosition, snpFile);
+
+    methbamparser->exportResult(chrName, chrSeq, chrLen, passPosition, result);
+#ifdef VALIDATE_EXPORT
+    #pragma omp critical (validate_export_dump)
+    {
+        std::ofstream out(params.resultPrefix + "_export_dump.tsv", std::ios::app);
+        out << result.str();
+    }
+#endif
+    delete methbamparser;
+
+    readVariantVec.clear();
+    readVariantVec.shrink_to_fit();
+    modReadVariantVec.clear();
+    modReadVariantVec.shrink_to_fit();
+
+    std::cerr<< "(" << chrName << "," << difftime(time(NULL), chrbegin) << "s)";
+}
 
 ModCallProcess::ModCallProcess(ModCallParameters params){
 
-     // load SNP vcf file
+    // load SNP vcf file
     std::time_t begin = time(NULL);
     std::cerr<< "parsing VCF ... ";
     MethSnpParser snpFile(params);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
-    
+
     // parsing ref fasta
-    begin= time(NULL);
+    begin = time(NULL);
     std::cerr<< "reading reference ... ";
     std::vector<ReferenceChromosome> chrInfo;
     MethFastaParser MethFastaParser(params.fastaFile, chrInfo);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
-    
-    // record all ModCall result
+
+    // record all ModCall result; pre-populate to avoid race conditions in parallel region
     std::map<std::string,std::ostringstream> chrModCallResult;
-    // Initialize an empty map in chrModCallResult to store all ModCall results.
-    // This is done to prevent issues with multi-threading, by defining an empty map first.
     for (auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); chrIter++) {
         chrModCallResult[chrIter->name] = std::ostringstream();
     }
 
-    // init data structure and get core n
     htsThreadPool threadPool = {NULL, 0};
-
-    // creat thread pool
     if (!(threadPool.pool = hts_tpool_init(params.numThreads))) {
         fprintf(stderr, "Error creating thread pool\n");
     }
 
     begin = time(NULL);
-    //loop all chromosomes
     #pragma omp parallel for schedule(dynamic) num_threads(params.numThreads)
     for(auto chrIter = chrInfo.begin(); chrIter != chrInfo.end(); ++chrIter) {
-        std::time_t chrbegin = time(NULL);
-        // store variant
-        std::vector<ReadVariant> modReadVariantVec;
-        std::vector<ReadVariant> readVariantVec;
-        // record hetero metyhl position
-        std::vector<int> *passPosition = new std::vector<int>;
-
-        std::string chrName = chrIter->name;
-        std::string chrSeq = chrIter->sequence;
-        int chrLen = chrIter->length;
-        
-        MethBamParser *methbamparser = new MethBamParser(chrName, params, snpFile, chrSeq);
-
-        methbamparser->detectMeth(chrName, chrLen, threadPool, readVariantVec);
-        //new new calculate depth
-        methbamparser->calculateDepth();
-        //judge methylation genotype
-        methbamparser->judgeMethGenotype(chrName, readVariantVec, modReadVariantVec);
-
-        MethylationGraph *modGraph = new MethylationGraph(params);
-        modGraph->addEdge(modReadVariantVec, chrName);
-
-        modGraph->connectResults(chrName, (*passPosition), snpFile.hasValidSnpData());
-        modGraph->destroy();
-        delete modGraph;
-        
-        //push result to ModCallResult
-        methbamparser->exportResult(chrName, chrSeq, chrLen, (*passPosition), chrModCallResult[chrName]);
-        passPosition->clear();
-        
-        delete methbamparser;
-        delete passPosition;
-        
-        readVariantVec.clear();
-        readVariantVec.shrink_to_fit();
-        modReadVariantVec.clear();
-        modReadVariantVec.shrink_to_fit();
-
-        std::cerr<< "(" << chrName << "," << difftime(time(NULL), chrbegin) << "s)";
+        processChromosome(*chrIter, params, threadPool, snpFile, chrModCallResult[chrIter->name]);
     }
     hts_tpool_destroy(threadPool.pool);
     std::cerr<< "\nmodcall total:  " << difftime(time(NULL), begin) << "s\n";
 
-    begin= time(NULL);
+    begin = time(NULL);
     std::cerr<<"write vcf " << " ... ";
-    //write to vcf file
     writeResultVCF(params, chrInfo, chrModCallResult);
     std::cerr<< difftime(time(NULL), begin) << "s\n";
 }

--- a/ParsingBam.cpp
+++ b/ParsingBam.cpp
@@ -1,1766 +1,1532 @@
 #include "ParsingBam.h"
 
-#include <string.h>
-#include <sstream>
+#include <cstdio>
 #include <cmath>
+#include <sstream>
+#include <string.h>
 
-
-// vcf parser modify from 
+// vcf parser modify from
 // http://wresch.github.io/2014/11/18/process-vcf-file-with-htslib.html
-// bam parser modify from 
+// bam parser modify from
 // https://github.com/whatshap/whatshap/blob/9882248c722b1020321fea6e9491c1cc5b75354b/whatshap/variants.py
 
-
 // FASTA
-FastaParser::FastaParser(std::string fastaFile,  std::vector<std::string> chrName, std::vector<int> last_pos, int numThreads):
-    fastaFile(fastaFile),
-    chrName(chrName),
-    last_pos(last_pos)
-{
-    // init map
-    for(std::vector<std::string>::iterator iter = chrName.begin() ; iter != chrName.end() ; iter++)
-        chrString.insert(std::make_pair( (*iter) , ""));
+FastaParser::FastaParser(std::string fastaFile,
+                         std::vector<std::string> chrName,
+                         std::vector<int> last_pos, int numThreads)
+    : fastaFile(fastaFile), chrName(chrName), last_pos(last_pos) {
+  // init map
+  for (std::vector<std::string>::iterator iter = chrName.begin();
+       iter != chrName.end(); iter++)
+    chrString.insert(std::make_pair((*iter), ""));
 
-    // load reference index
-    faidx_t *fai = NULL;
-    fai = fai_load(fastaFile.c_str());
-    
-    // iterating all chr
-    //#pragma omp parallel for schedule(dynamic) num_threads(numThreads)
-    for(std::vector<std::string>::iterator iter = chrName.begin() ; iter != chrName.end() ; iter++){
-        
-        int index = iter - chrName.begin();
-        
-        // Do not extract references without SNP coverage.
-        if( last_pos.at(index) == -1){
-            chrString[(*iter)]="";
-            continue;
-        }
-        
-        // ref_len is a return value that is length of retrun string
-        int ref_len = 0;
+  // load reference index
+  faidx_t *fai = NULL;
+  fai = fai_load(fastaFile.c_str());
 
-        // read file
-        std::string chr_info(faidx_fetch_seq(fai , (*iter).c_str() , 0 , last_pos.at(index)+5 , &ref_len));
-        if(ref_len == 0){
-            std::cout<<"nothing in reference file \n";
-        }
+  // iterating all chr
+  // #pragma omp parallel for schedule(dynamic) num_threads(numThreads)
+  for (std::vector<std::string>::iterator iter = chrName.begin();
+       iter != chrName.end(); iter++) {
 
-        // update map
-        chrString[(*iter)] = chr_info;
+    int index = iter - chrName.begin();
+
+    // Do not extract references without SNP coverage.
+    if (last_pos.at(index) == -1) {
+      chrString[(*iter)] = "";
+      continue;
     }
+
+    // ref_len is a return value that is length of retrun string
+    int ref_len = 0;
+
+    // read file
+    std::string chr_info(faidx_fetch_seq(fai, (*iter).c_str(), 0,
+                                         last_pos.at(index) + 5, &ref_len));
+    if (ref_len == 0) {
+      std::cout << "nothing in reference file \n";
+    }
+
+    // update map
+    chrString[(*iter)] = chr_info;
+  }
 }
 
-FastaParser::~FastaParser(){
- 
-}
+FastaParser::~FastaParser() {}
 
+void BaseVairantParser::readGzLines(
+    const std::string &variantFile,
+    std::function<void(const std::string &)> callback) {
+  gzFile file = gzopen(variantFile.c_str(), "rb");
+  if (!file) {
+    std::cout << "Fail to open vcf: " << variantFile << "\n";
+    return;
+  }
+  int buffer_size = 1048576; // 1M
+  char *buffer = (char *)malloc(buffer_size);
+  if (!buffer) {
+    std::cerr << "Failed to allocate buffer\n";
+    exit(EXIT_FAILURE);
+  }
+  char *offset = buffer;
 
-void BaseVairantParser::compressParser(std::string &variantFile){
-    gzFile file = gzopen(variantFile.c_str(), "rb");
-    if(variantFile=="")
-        return;
-    if(!file){
-        std::cout<< "Fail to open vcf: " << variantFile << "\n";
-    }
-    else{  
-        int buffer_size = 1048576; // 1M
-        char* buffer = (char*) malloc(buffer_size);
-        if(!buffer){
-            std::cerr<<"Failed to allocate buffer\n";
-            exit(EXIT_FAILURE);
-        }
-        char* offset = buffer;
-            
-        while(true) {
-            int len = buffer_size - (offset - buffer);
-            if (len == 0){
-                buffer_size *= 2; // Double the buffer size
-                char* new_buffer = (char*) realloc(buffer, buffer_size);
-                if(!new_buffer){
-                    std::cerr<<"Failed to allocate buffer\n";
-                    free(buffer);
-                    exit(EXIT_FAILURE);
-                }
-                buffer = new_buffer;
-                offset = buffer + buffer_size / 2; // Update the offset pointer to the end of the old buffer
-                len = buffer_size - (offset - buffer);
-            }
-
-            len = gzread(file, offset, len);
-            if (len == 0) break;    
-            if (len <  0){ 
-                int err;
-                fprintf (stderr, "Error: %s.\n", gzerror(file, &err));
-                exit(EXIT_FAILURE);
-            }
-
-            char* cur = buffer;
-            char* end = offset+len;
-            for (char* eol; (cur<end) && (eol = std::find(cur, end, '\n')) < end; cur = eol + 1)
-            {
-                std::string input = std::string(cur, eol);
-                parserProcess(input);
-            }
-            // any trailing data in [eol, end) now is a partial line
-            offset = std::copy(cur, end, buffer);
-        }
-        gzclose (file);
+  while (true) {
+    int len = buffer_size - (offset - buffer);
+    if (len == 0) {
+      buffer_size *= 2; // Double the buffer size
+      char *new_buffer = (char *)realloc(buffer, buffer_size);
+      if (!new_buffer) {
+        std::cerr << "Failed to allocate buffer\n";
         free(buffer);
-    }    
+        exit(EXIT_FAILURE);
+      }
+      buffer = new_buffer;
+      offset =
+          buffer +
+          buffer_size /
+              2; // Update the offset pointer to the end of the old buffer
+      len = buffer_size - (offset - buffer);
+    }
+
+    len = gzread(file, offset, len);
+    if (len == 0)
+      break;
+    if (len < 0) {
+      int err;
+      fprintf(stderr, "Error: %s.\n", gzerror(file, &err));
+      exit(EXIT_FAILURE);
+    }
+
+    char *cur = buffer;
+    char *end = offset + len;
+    for (char *eol; (cur < end) && (eol = std::find(cur, end, '\n')) < end;
+         cur = eol + 1) {
+      callback(std::string(cur, eol));
+    }
+    // any trailing data in [eol, end) now is a partial line
+    offset = std::copy(cur, end, buffer);
+  }
+  gzclose(file);
+  free(buffer);
 }
 
-void BaseVairantParser::unCompressParser(std::string &variantFile){
-    std::ifstream originVcf(variantFile);
-    if(variantFile=="")
-        return;
-    if(!originVcf.is_open()){
-        std::cout<< "Fail to open vcf: " << variantFile << "\n";
-        exit(1);
-    }
-    else{
-        std::string input;
-        while(! originVcf.eof() ){
-            std::getline(originVcf, input);
-            parserProcess(input);
-        }
-    }
+void BaseVairantParser::compressParser(std::string &variantFile) {
+  if (variantFile == "") return;
+  readGzLines(variantFile, [this](const std::string &line) {
+    parserProcess(const_cast<std::string &>(line));
+  });
 }
 
-void BaseVairantParser::compressInput(std::string variantFile, std::string resultFile, PhasingResult phasingResult){
-    
-    gzFile file = gzopen(variantFile.c_str(), "rb");
-    std::ofstream resultVcf(resultFile);
-    
-    if(!resultVcf.is_open()){
-        std::cout<< "Fail to open write file: " << resultFile << "\n";
+void BaseVairantParser::unCompressParser(std::string &variantFile) {
+  std::ifstream originVcf(variantFile);
+  if (variantFile == "")
+    return;
+  if (!originVcf.is_open()) {
+    std::cout << "Fail to open vcf: " << variantFile << "\n";
+    exit(1);
+  } else {
+    std::string input;
+    while (!originVcf.eof()) {
+      std::getline(originVcf, input);
+      parserProcess(input);
     }
-    else if(!file){
-        std::cout<< "Fail to open vcf: " << variantFile << "\n";
-    }
-    else{
-        
-        bool ps_def = false;
-        int buffer_size = 1048576; // 1M
-        char* buffer = (char*) malloc(buffer_size);
-        if(!buffer){
-            std::cerr<<"Failed to allocate buffer\n";
-            exit(EXIT_FAILURE);
-        }
-        char* offset = buffer;
-            
-        while(true) {
-            int len = buffer_size - (offset - buffer);
-            if (len == 0){
-                buffer_size *= 2; // Double the buffer size
-                char* new_buffer = (char*) realloc(buffer, buffer_size);
-                if(!new_buffer){
-                    std::cerr<<"Failed to allocate buffer\n";
-                    free(buffer);
-                    exit(EXIT_FAILURE);
-                }
-                buffer = new_buffer;
-                offset = buffer + buffer_size / 2; // Update the offset pointer to the end of the old buffer
-                len = buffer_size - (offset - buffer);
-            }
-
-            len = gzread(file, offset, len);
-            if (len == 0) break;    
-            if (len <  0){ 
-                int err;
-                fprintf (stderr, "Error: %s.\n", gzerror(file, &err));
-                exit(EXIT_FAILURE);
-            }
-
-            char* cur = buffer;
-            char* end = offset+len;
-            for (char* eol; (cur<end) && (eol = std::find(cur, end, '\n')) < end; cur = eol + 1)
-            {
-                std::string input = std::string(cur, eol);
-                //parserProcess(input);
-                writeLine(input, ps_def, resultVcf, phasingResult);
-            }
-            // any trailing data in [eol, end) now is a partial line
-            offset = std::copy(cur, end, buffer);
-        }
-        gzclose (file);
-        free(buffer);
-    }
+  }
 }
 
-void BaseVairantParser::unCompressInput(std::string variantFile, std::string resultFile, PhasingResult phasingResult){
-    std::ifstream originVcf(variantFile);
-    std::ofstream resultVcf(resultFile);
-    
-    if(!resultVcf.is_open()){
-        std::cout<< "Fail to open write file: " << resultFile << "\n";
-    }
-    else if(!originVcf.is_open()){
-        std::cout<< "Fail to open vcf: " << variantFile << "\n";
-    }
-    else{
-        bool ps_def = false;
-        std::string input;
-        while(! originVcf.eof() ){
-            std::getline(originVcf, input);
-            if( input != "" ){
-                writeLine(input, ps_def, resultVcf, phasingResult);
-            }
-        }
-    }
+void BaseVairantParser::compressInput(std::string variantFile,
+                                      std::string resultFile,
+                                      PhasingResult phasingResult) {
+  if (variantFile == "") return;
+  std::ofstream resultVcf(resultFile);
+  if (!resultVcf.is_open()) {
+    std::cout << "Fail to open write file: " << resultFile << "\n";
+    return;
+  }
+  bool ps_def = false;
+  readGzLines(variantFile, [&](const std::string &line) {
+    writeLine(const_cast<std::string &>(line), ps_def, resultVcf, phasingResult);
+  });
 }
 
+void BaseVairantParser::unCompressInput(std::string variantFile,
+                                        std::string resultFile,
+                                        PhasingResult phasingResult) {
+  std::ifstream originVcf(variantFile);
+  std::ofstream resultVcf(resultFile);
+
+  if (!resultVcf.is_open()) {
+    std::cout << "Fail to open write file: " << resultFile << "\n";
+  } else if (!originVcf.is_open()) {
+    std::cout << "Fail to open vcf: " << variantFile << "\n";
+  } else {
+    bool ps_def = false;
+    std::string input;
+    while (!originVcf.eof()) {
+      std::getline(originVcf, input);
+      if (input != "") {
+        writeLine(input, ps_def, resultVcf, phasingResult);
+      }
+    }
+  }
+}
+
+void BaseVairantParser::dispatchWriteResult(const std::string &inputFile,
+                                            const std::string &outputFile,
+                                            PhasingResult phasingResult) {
+  if (inputFile.find("gz") != std::string::npos)
+    compressInput(inputFile, outputFile, phasingResult);
+  else if (inputFile.find("vcf") != std::string::npos)
+    unCompressInput(inputFile, outputFile, phasingResult);
+}
+
+void BaseVairantParser::writeLine(std::string &input, bool &ps_def,
+                                  std::ofstream &resultVcf,
+                                  PhasingResult &phasingResult) {
+  if (input.substr(0, 2) == "##")
+    writeMetaHeader(input, ps_def, resultVcf);
+  else if (input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom")
+    writeColumnHeader(input, ps_def, resultVcf);
+  else
+    writeDataLine(input, resultVcf, phasingResult);
+}
+
+void BaseVairantParser::writeMetaHeader(const std::string &input, bool &ps_def,
+                                        std::ofstream &resultVcf) {
+  if (input.substr(0, 16) == "##FORMAT=<ID=PS,")
+    ps_def = true;
+  resultVcf << input << "\n";
+}
+
+void BaseVairantParser::writeColumnHeader(const std::string &input,
+                                          bool &ps_def,
+                                          std::ofstream &resultVcf) {
+  if (commandLine == false) {
+    if (ps_def == false) {
+      resultVcf << "##FORMAT=<ID=PS,Number=1,Type=Integer,Description="
+                   "\"Phase set identifier\">\n";
+      ps_def = true;
+    }
+    resultVcf << "##longphaseVersion=" << params->version << "\n";
+    resultVcf << "##commandline=\"" << params->command << "\"\n";
+    commandLine = true;
+  }
+  resultVcf << input << "\n";
+}
+
+static bool isHetGt(const int *gt) {
+  return (gt[0] == 2 && gt[1] == 4) || // 0/1
+         (gt[0] == 4 && gt[1] == 2) || // 1/0
+         (gt[0] == 2 && gt[1] == 5) || // 0|1
+         (gt[0] == 4 && gt[1] == 3);   // 1|0
+}
+
+static void parseReadList(
+    const std::string &info, const std::string &tag,
+    const std::string &chr, int repPos, bool is_reverse, bool is_modify,
+    std::map<std::string, std::map<int, std::map<std::string, ModVariant>>> &chrVariant) {
+  size_t read_pos = info.find(tag);
+  read_pos = info.find("=", read_pos) + 1;
+  size_t next_field = info.find(";", read_pos);
+  std::string totalRead = info.substr(read_pos, next_field - read_pos);
+  std::stringstream ss(totalRead);
+  std::string read;
+  while (std::getline(ss, read, ',')) {
+    ModVariant tmp;
+    tmp.is_reverse = is_reverse;
+    tmp.is_modify = is_modify;
+    chrVariant[chr][repPos][read] = tmp;
+  }
+}
 
 // SNP
-SnpParser::SnpParser(PhasingParameters &in_params):commandLine(false){
+SnpParser::SnpParser(PhasingParameters &in_params) {
 
-    chrVariant = new std::map<std::string, std::map<int, RefAlt> >;
-    
-    params = &in_params;
-        
-    // Initialize removed indels log file
+  chrVariant = new std::map<std::string, std::map<int, SnpVariant>>;
+
+  params = &in_params;
+
+  // open vcf file
+  htsFile *inf = bcf_open(params->snpFile.c_str(), "r");
+  // read header
+  bcf_hdr_t *hdr = bcf_hdr_read(inf);
+  // counters
+  int nseq = 0;
+  // report names of all the sequences in the VCF file
+  const char **seqnames = NULL;
+  // chromosome idx and name
+  seqnames = bcf_hdr_seqnames(hdr, &nseq);
+  // store chromosome
+  for (int i = 0; i < nseq; i++) {
+    // bcf_hdr_id2name is another way to get the name of a sequence
+    chrName.push_back(seqnames[i]);
+  }
+  // set all sample string
+  std::string allSmples = "-";
+  // limit the VCF data to the sample name passed in
+  int is_file = bcf_hdr_set_samples(hdr, allSmples.c_str(), 0);
+  if (is_file != 0) {
+    std::cout << "error or a positive integer if the list contains samples not "
+                 "present in the VCF header\n";
+  }
+
+  // struct for storing each record
+  bcf1_t *rec = bcf_init();
+  int ngt_arr = 0;
+  int ngt = 0;
+  int *gt = NULL;
+
+  // loop vcf line
+  while (bcf_read(inf, hdr, rec) == 0) {
+    // snp
+    if (bcf_is_snp(rec)) {
+      ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
+
+      if (ngt < 0) {
+        std::cerr << "pos " << rec->pos << " missing GT value" << "\n";
+        exit(1);
+      }
+
+      // just phase hetero SNP
+      if (isHetGt(gt)) {
+
+        // get chromosome string
+        std::string chr = seqnames[rec->rid];
+        // position is 0-base
+        int variantPos = rec->pos;
+        // get r alleles
+        SnpVariant tmp;
+        tmp.Ref = rec->d.allele[0];
+        tmp.Alt = rec->d.allele[1];
+
+        // prevent the MAVs calling error which makes the GT=0/1
+        if (rec->d.allele[1][2] != '\0') {
+          continue;
+        }
+
+        // record
+        (*chrVariant)[chr][variantPos] = tmp;
+      }
+    }
+    // indel
+    else if (params->phaseIndel) {
+      ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
+
+      if (ngt < 0) {
+        std::cerr << "pos " << rec->pos << " missing GT value" << "\n";
+        exit(1);
+      }
+
+      if (isHetGt(gt)) {
+
+        // get chromosome string
+        std::string chr = seqnames[rec->rid];
+        // position is 0-base
+        int variantPos = rec->pos;
+        // get r alleles
+        SnpVariant tmp;
+        tmp.Ref = rec->d.allele[0];
+        tmp.Alt = rec->d.allele[1];
+
+        float qual = rec->qual;
+        if (std::isnan(qual)) {
+          qual = 0.0;
+        }
+
+        // prevent the MAVs calling error which makes the GT=0/1
+        if (rec->d.allele[1][tmp.Alt.size() + 1] != '\0') {
+          continue;
+        }
+
+        // record
+        (*chrVariant)[chr][variantPos] = tmp;
+      }
+    }
+  }
+}
+
+SnpParser::~SnpParser() { delete chrVariant; }
+
+std::map<int, SnpVariant> SnpParser::getVariants(std::string chrName) {
+  std::map<int, SnpVariant> targetVariants;
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrIter =
+      chrVariant->find(chrName);
+
+  if (chrIter != chrVariant->end())
+    targetVariants = (*chrIter).second;
+
+  return targetVariants;
+}
+
+std::map<int, SnpVariant>
+SnpParser::getVariants_markindel(std::string chrName, const std::string &ref) {
+  std::map<int, SnpVariant> targetVariants;
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrIter =
+      chrVariant->find(chrName);
+
+  // Mark the indel which lies in the tandem repeat
+  if (chrIter != chrVariant->end()) {
+    for (auto innerIter = chrIter->second.begin();
+         innerIter != chrIter->second.end(); innerIter++) {
+      innerIter->second.is_danger = isDangerIndel(
+          innerIter->first, ref, innerIter->second.Ref.length(),
+          innerIter->second.Alt.length());
+    }
+
+    targetVariants = (*chrIter).second;
+  }
+
+  return targetVariants;
+}
+
+std::vector<std::string> SnpParser::getChrVec() { return chrName; }
+
+
+int SnpParser::getLastSNP(std::string chrName) {
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrVariantIter =
+      chrVariant->find(chrName);
+  // this chromosome not exist in this file.
+  if (chrVariantIter == chrVariant->end())
+    return -1;
+  // get last SNP
+  std::map<int, SnpVariant>::reverse_iterator lastVariantIter =
+      (*chrVariantIter).second.rbegin();
+  // there are no SNPs on this chromosome
+  if (lastVariantIter == (*chrVariantIter).second.rend())
+    return -1;
+  return (*lastVariantIter).first;
+}
+
+void SnpParser::writeResult(PhasingResult phasingResult) {
+  dispatchWriteResult(params->snpFile, params->resultPrefix + ".vcf",
+                      phasingResult);
+}
+
+void SnpParser::parserProcess(std::string &input) {}
+
+void SnpParser::writeMetaHeader(const std::string &input, bool &ps_def,
+                               std::ofstream &resultVcf) {
+  if (input.substr(0, 16) == "##FORMAT=<ID=PS,") {
+    ps_def = true;
+  }
+  if (input.substr(0, 17) == "##FILTER=<ID=PASS") {
+    resultVcf << input << "\n";
     if (params->phaseIndel && params->indelQuality > 0) {
-        std::string logFileName = params->resultPrefix + "_removed_indels.log";
-        removedIndelsLog.open(logFileName.c_str());
-        if (removedIndelsLog.is_open()) {
-            removedIndelsLog << "#CHROM\tPOS\tREF\tALT\tQUAL\n";
-        }
+      resultVcf << "##FILTER=<ID=INDEL_QUAL_FILTERED,Description=\"Indel "
+                   "filtered due to QUAL below threshold ("
+                << params->indelQuality << ")\">\n";
     }
-
-    // open vcf file
-    htsFile * inf = bcf_open(params->snpFile.c_str(), "r");
-    // read header
-    bcf_hdr_t *hdr = bcf_hdr_read(inf);
-    // counters
-    int nseq = 0;
-    // report names of all the sequences in the VCF file
-    const char **seqnames = NULL;
-    // chromosome idx and name
-    seqnames = bcf_hdr_seqnames(hdr, &nseq);
-    // store chromosome
-    for (int i = 0; i < nseq; i++) {
-        // bcf_hdr_id2name is another way to get the name of a sequence
-        chrName.push_back(seqnames[i]);
-    }
-    // set all sample string
-    std::string allSmples = "-";
-    // limit the VCF data to the sample name passed in
-    int is_file = bcf_hdr_set_samples(hdr, allSmples.c_str(), 0);
-    if( is_file != 0 ){
-        std::cout << "error or a positive integer if the list contains samples not present in the VCF header\n";
-    }
-
-    // struct for storing each record
-    bcf1_t *rec = bcf_init();
-    int ngt_arr = 0;
-    int ngt = 0;
-    int *gt     = NULL;
-    
-    // loop vcf line 
-    while (bcf_read(inf, hdr, rec) == 0) {
-        // snp
-        if (bcf_is_snp(rec)) {
-            ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
-
-            if(ngt<0){
-                std::cerr<< "pos " << rec->pos << " missing GT value" << "\n";
-                exit(1);
-            }
-            
-            // just phase hetero SNP
-            if ( (gt[0] == 2 && gt[1] == 4) || // 0/1
-                 (gt[0] == 4 && gt[1] == 2) || // 1/0
-                 (gt[0] == 2 && gt[1] == 5) || // 0|1
-                 (gt[0] == 4 && gt[1] == 3)    // 1|0 
-                ) {
-                
-                // get chromosome string
-                std::string chr = seqnames[rec->rid];
-                // position is 0-base
-                int variantPos = rec->pos;
-                // get r alleles
-                RefAlt tmp;
-                tmp.Ref = rec->d.allele[0]; 
-                tmp.Alt = rec->d.allele[1];
-                
-                //prevent the MAVs calling error which makes the GT=0/1
-                if ( rec->d.allele[1][2] != '\0' ){
-                    continue;
-                }
-                
-                // record 
-                (*chrVariant)[chr][variantPos] = tmp;
-            }
-        } 
-        // indel 
-        else if ( params->phaseIndel ){
-            ngt = bcf_get_format_int32(hdr, rec, "GT", &gt, &ngt_arr);
-            
-            if(ngt<0){
-                std::cerr<< "pos " << rec->pos << " missing GT value" << "\n";
-                exit(1);
-            }
-            
-            if ( (gt[0] == 2 && gt[1] == 4) || // 0/1
-                 (gt[0] == 4 && gt[1] == 2) || // 1/0
-                 (gt[0] == 2 && gt[1] == 5) || // 0|1
-                 (gt[0] == 4 && gt[1] == 3)    // 1|0 
-                ) {
-                    
-                // get chromosome string
-                std::string chr = seqnames[rec->rid];
-                // position is 0-base
-                int variantPos = rec->pos;
-                // get r alleles
-                RefAlt tmp;
-                tmp.Ref = rec->d.allele[0]; 
-                tmp.Alt = rec->d.allele[1];
-                
-                float qual = rec->qual;
-                if (std::isnan(qual)) {
-                    qual = 0.0;
-                }
-                if (params->indelQuality > 0 && qual < params->indelQuality){
-                    if (removedIndelsLog.is_open()) {
-                        removedIndelsLog << chr << "\t" << (variantPos + 1) << "\t" 
-                                        << tmp.Ref << "\t" << tmp.Alt << "\t" 
-                                        << (std::isnan(rec->qual) ? "." : std::to_string(rec->qual)) << "\n";
-                    }
-                    // Record the position of filtered indels (0-based)
-                    filteredIndelPositions[chr].insert(variantPos);
-                    continue;
-                }
-
-
-                
-                //prevent the MAVs calling error which makes the GT=0/1
-                if ( rec->d.allele[1][tmp.Alt.size()+1] != '\0' ){
-                   continue ;
-                }
-                
-                // record 
-                (*chrVariant)[chr][variantPos] = tmp;
-            }
-        }
-    }
+  } else {
+    resultVcf << input << "\n";
+  }
 }
 
-SnpParser::~SnpParser(){
-    if (removedIndelsLog.is_open()) {
-        removedIndelsLog.close();
-    }
-    delete chrVariant;
-}
 
-std::map<int, RefAlt> SnpParser::getVariants(std::string chrName){
-    std::map<int, RefAlt> targetVariants;
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
-    
-    if( chrIter != chrVariant->end() )
-        targetVariants = (*chrIter).second;
-    
-    return targetVariants;
-}
+void SnpParser::writeDataLine(const std::string &input,
+                              std::ofstream &resultVcf,
+                              PhasingResult &phasingResult) {
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
 
-std::map<int, RefAlt> SnpParser::getVariants_markindel(std::string chrName, const std::string &ref){
-    std::map<int, RefAlt> targetVariants;
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chrName);
-
-    //Mark the indel which lies in the tandem repeat
-    if (chrIter != chrVariant->end()) {
-    // Accessing the inner map using chrIter->second and iterating over it
-        for ( auto innerIter = chrIter->second.begin(); innerIter != chrIter->second.end(); innerIter++ ) {
-            int variant_pos = innerIter->first;      // Accessing the variant_pos of the inner map
-            RefAlt variant_info = innerIter->second; // Accessing the variant_info of the inner map
-            int ref_pos = variant_pos ;
-	        bool danger = false ;
-
-            std::string repeat = ref.substr(ref_pos + 1, 2) ; // get the 2 words string in the reference which behind the indel position
-            int i = 0 ;
-	    //check if there has 2 words tandem repeat in the reference
-            while ( i < 5 && (variant_info.Ref.length()>1 ||variant_info.Alt.length()>1) /*&& repeat[0]!=repeat[1]*/ ) {
-                if ( repeat[0] != ref[ref_pos+1] || repeat[1] != ref[ref_pos+2] ) {
-                    break ;
-                }
-
-                ref_pos = ref_pos + 2 ;
-                i++ ;
-            }
-
-	    // set the dnager to true if the repeat word repeats at least five times
-	    if ( i == 5 ) danger = true ;
-
-            innerIter->second.is_danger = danger ;
-
-        }
-
-        targetVariants = (*chrIter).second;
-    }
-    else {
-        // Handle the case where chrName doesn't exist in chrVariant
-    }
-
-    return targetVariants;
-}
-
-std::vector<std::string> SnpParser::getChrVec(){
-    return chrName;
-}
-
-/*bool SnpParser::findChromosome(std::string chrName){
-    std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
-    // this chromosome not exist in this file. 
-    if(chrVariantIter == chrVariant->end())
-        return false;
-    return true;
-}*/
-
-int SnpParser::getLastSNP(std::string chrName){
-    std::map<std::string, std::map< int, RefAlt > >::iterator chrVariantIter = chrVariant->find(chrName);
-    // this chromosome not exist in this file. 
-    if(chrVariantIter == chrVariant->end())
-        return -1;
-    // get last SNP
-    std::map< int, RefAlt >::reverse_iterator lastVariantIter = (*chrVariantIter).second.rbegin();
-    // there are no SNPs on this chromosome
-    if(lastVariantIter == (*chrVariantIter).second.rend())
-        return -1;
-    return (*lastVariantIter).first;
-}
-
-void SnpParser::writeResult(PhasingResult phasingResult){
-
-    if( params->snpFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
-    }
-    else if( params->snpFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressInput(params->snpFile, params->resultPrefix+".vcf", phasingResult);
-    }
+  if (fields.size() == 0)
     return;
+
+  int pos = std::stoi(fields[1]);
+  int posIdx = pos - 1;
+  std::string key = fields[0] + "_" + std::to_string(posIdx);
+
+  PhasingResult::iterator psElementIter = phasingResult.find(key);
+
+  // PS flag already exist, erase PS info
+  if (fields[8].find("PS") != std::string::npos) {
+    std::string format_before_ps_erase = fields[8];
+    int ps_pos = fields[8].find("PS");
+
+    // erase PS flag
+    if (fields[8].find(":", ps_pos + 1) != std::string::npos) {
+      fields[8].erase(ps_pos, 3);
+    } else {
+      fields[8].erase(ps_pos - 1, 3);
+    }
+
+    int ps_start = findFieldValueStart(format_before_ps_erase, fields[9], "PS");
+
+    if (fields[9].find(":", ps_start + 1) != std::string::npos) {
+      int ps_end_pos = fields[9].find(":", ps_start + 1);
+      fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
+    } else {
+      fields[9].erase(ps_start - 1, fields[9].length() - ps_start + 1);
+    }
+  }
+  // reset GT flag
+  if (fields[8].find("GT") != std::string::npos) {
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    if (fields[9][modify_start + 1] == '|') {
+      // direct modify GT value
+      if (fields[9][modify_start] > fields[9][modify_start + 2]) {
+        fields[9][modify_start + 1] = fields[9][modify_start];
+        fields[9][modify_start] = fields[9][modify_start + 2];
+        fields[9][modify_start + 2] = fields[9][modify_start + 1];
+      }
+      fields[9][modify_start + 1] = '/';
+    }
+  }
+
+  // Check if the variant is extracted from this VCF
+  auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+
+  // Check if this indel was filtered out due to quality
+  bool isFilteredIndel = false;
+  if (params->phaseIndel && params->indelQuality > 0) {
+    auto filteredIter = filteredIndelPositions.find(fields[0]);
+    if (filteredIter != filteredIndelPositions.end()) {
+      if (filteredIter->second.find(posIdx) != filteredIter->second.end()) {
+        isFilteredIndel = true;
+      }
+    }
+  }
+
+  // this pos is phase
+  if (psElementIter != phasingResult.end() &&
+      posIter != (*chrVariant)[fields[0]].end()) {
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] =
+        fields[9] + ":" + std::to_string((*psElementIter).second.block);
+
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    // direct modify GT value
+    fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
+    fields[9][modify_start + 1] = '|';
+    fields[9][modify_start + 2] = (*psElementIter).second.RAstatus[2];
+  }
+  // this pos has not been phased
+  else {
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] = fields[9] + ":.";
+  }
+
+  // Add FILTER tag for filtered indels
+  if (isFilteredIndel) {
+    // Overwrite to INDEL_QUAL_FILTERED, do not keep the original tag
+    fields[6] = "INDEL_QUAL_FILTERED";
+  }
+
+  for (std::vector<std::string>::iterator fieldIter = fields.begin();
+       fieldIter != fields.end(); ++fieldIter) {
+    if (fieldIter != fields.begin())
+      resultVcf << "\t";
+    resultVcf << (*fieldIter);
+  }
+  resultVcf << "\n";
 }
 
-void SnpParser::parserProcess(std::string &input){
+bool SnpParser::findSNP(std::string chr, int position) {
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrIter =
+      chrVariant->find(chr);
+  // empty chromosome
+  if (chrIter == chrVariant->end())
+    return false;
+
+  std::map<int, SnpVariant>::iterator posIter =
+      (*chrVariant)[chr].find(position);
+  // empty position
+  if (posIter == (*chrVariant)[chr].end())
+    return false;
+
+  return true;
 }
 
-void SnpParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
-    // header
-    if( input.substr(0, 2) == "##" ){
-        // avoid double definition
-        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
-            ps_def = true;
-        }
-                // Add  FILTER definition
-        if( input.substr(0, 17) == "##FILTER=<ID=PASS" ){
-            resultVcf << input << "\n";
-            // Add FILTER definition for indel quality filtering
-            if (params->phaseIndel && params->indelQuality > 0) {
-                resultVcf << "##FILTER=<ID=INDEL_QUAL_FILTERED,Description=\"Indel filtered due to QUAL below threshold (" << params->indelQuality << ")\">\n";
-            }
-        } else {
-            resultVcf << input << "\n";
-        }
+void SnpParser::filterSNP(std::string chr,
+                          std::vector<ReadVariant> &readVariantVec,
+                          std::string &chr_reference) {
+
+  // pos, <allele, <strand, True>
+  std::map<int, std::map<int, std::map<int, bool>>> posAlleleStrand;
+  std::map<int, bool> methylation;
+
+  /*
+  // iter all variant, record the strand contained in each SNP
+  for( auto readSNPVecIter : readVariantVec ){
+      // tag allele on forward or reverse strand
+      for(auto variantIter : readSNPVecIter.variantVec ){
+          posAlleleStrand[variantIter.position][variantIter.allele][readSNPVecIter.is_reverse]
+  = true;
+      }
+  }
+
+  // iter all SNP, both alleles that require SNP need to appear in the two
+  strand for(auto pos: posAlleleStrand){
+      // this position contain two allele, REF allele appear in the two strand,
+  ALT allele appear in the two strand if(pos.second.size() == 2 &&
+  pos.second[0].size() == 2 && pos.second[1].size() == 2 ){
+          // high confident SNP
+      }
+      else{
+          //methylation[pos.first] = true;
+      }
+  }
+  */
+
+  // Filter SNPs that are not easy to phasing due to homopolymer
+  // get variant list
+  std::map<std::string, std::map<int, SnpVariant>>::iterator chrIter =
+      chrVariant->find(chr);
+  std::map<int, bool> errorProneSNP;
+
+  if (chrIter != chrVariant->end()) {
+    std::map<int, int> consecutiveAllele;
+    // iter all SNP and tag homopolymer
+    for (std::map<int, SnpVariant>::iterator posIter =
+             (*chrIter).second.begin();
+         posIter != (*chrIter).second.end(); posIter++) {
+      consecutiveAllele[(*posIter).first] =
+          homopolymerLength((*posIter).first, chr_reference);
     }
-    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
-        // format line 
-        if( commandLine == false ){
-            if(ps_def == false){
-                resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
-                ps_def = true;
-            }
-            resultVcf << "##longphaseVersion=" << params->version << "\n";
-            resultVcf << "##commandline=\"" << params->command << "\"\n";
-            commandLine = true;
-        }
-        resultVcf << input << "\n";
+    std::map<int, SnpVariant>::iterator currSNPIter = (*chrIter).second.begin();
+    std::map<int, SnpVariant>::iterator nextSNPIter = std::next(currSNPIter, 1);
+    // check whether each SNP pair falls in an area that is not easy to phasing
+    while (currSNPIter != (*chrIter).second.end() &&
+           nextSNPIter != (*chrIter).second.end()) {
+      int currPos = (*currSNPIter).first;
+      int nextPos = (*nextSNPIter).first;
+      // filter one of SNP if this SNP pair falls in homopolymer and distance<=2
+      if (consecutiveAllele[currPos] >= 3 && consecutiveAllele[nextPos] >= 3 &&
+          std::abs(currPos - nextPos) <= 2) {
+        errorProneSNP[nextPos] = true;
+        nextSNPIter = (*chrIter).second.erase(nextSNPIter);
+        continue;
+      }
+
+      currSNPIter++;
+      nextSNPIter++;
     }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+  }
 
-        if( fields.size() == 0 )
-            return;
+  // iter all reads
+  for (std::vector<ReadVariant>::iterator readSNPVecIter =
+           readVariantVec.begin();
+       readSNPVecIter != readVariantVec.end(); readSNPVecIter++) {
+    // iter all SNPs in this read
+    for (std::vector<Variant>::iterator variantIter =
+             (*readSNPVecIter).variantVec.begin();
+         variantIter != (*readSNPVecIter).variantVec.end();) {
+      std::map<int, bool>::iterator delSNPIter =
+          methylation.find((*variantIter).position);
+      std::map<int, bool>::iterator homoIter =
+          errorProneSNP.find((*variantIter).position);
 
-        int pos = std::stoi( fields[1] );
-        int posIdx = pos - 1 ;
-        std::string key = fields[0] + "_" + std::to_string(posIdx);
-
-        PhasingResult::iterator psElementIter =  phasingResult.find(key);
-
-        // PS flag already exist, erase PS info
-        if( fields[8].find("PS")!= std::string::npos ){
-
-            // find PS flag
-            int colon_pos = 0;
-            int ps_pos = fields[8].find("PS");
-            for(int i =0 ; i< ps_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-                                
-            // erase PS flag
-            if( fields[8].find(":",ps_pos+1) != std::string::npos ){
-                fields[8].erase(ps_pos, 3);
-            }
-            else{
-                fields[8].erase(ps_pos - 1, 3);
-            }
-                            
-            // find PS value start
-            int current_colon = 0;
-            int ps_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                ps_start++;
-            }
-                            
-            // erase PS value
-            if( fields[9].find(":",ps_start+1) != std::string::npos ){
-                int ps_end_pos = fields[9].find(":",ps_start+1);
-                fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
-            }
-            else{
-                fields[9].erase(ps_start-1, fields[9].length() - ps_start + 1);
-            }
-        }
-        // reset GT flag
-        if( fields[8].find("GT")!= std::string::npos ){
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            if(fields[9][modify_start+1] == '|'){
-                // direct modify GT value
-                if(fields[9][modify_start] > fields[9][modify_start+2]){
-                    fields[9][modify_start+1] = fields[9][modify_start];
-                    fields[9][modify_start] = fields[9][modify_start+2];
-                    fields[9][modify_start+2] =fields[9][modify_start+1];
-                }
-                fields[9][modify_start+1] = '/';
-            }   
-        }
-
-        // Check if the variant is extracted from this VCF
-        auto posIter = (*chrVariant)[fields[0]].find(posIdx);
-        
-        // Check if this indel was filtered out due to quality
-        bool isFilteredIndel = false;
-        if (params->phaseIndel && params->indelQuality > 0) {
-            auto filteredIter = filteredIndelPositions.find(fields[0]);
-            if (filteredIter != filteredIndelPositions.end()) {
-                if (filteredIter->second.find(posIdx) != filteredIter->second.end()) {
-                    isFilteredIndel = true;
-                }
-            }
-        }
-        
-        // this pos is phase
-        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
-                        
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-                }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            // direct modify GT value
-            fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
-            fields[9][modify_start+1] = '|';
-            fields[9][modify_start+2] = (*psElementIter).second.RAstatus[2];
-        }
-        // this pos has not been phased
-        else{
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":.";
-        }
-
-        // Add FILTER tag for filtered indels
-        if (isFilteredIndel) {
-            // Overwrite to INDEL_QUAL_FILTERED, do not keep the original tag
-            fields[6] = "INDEL_QUAL_FILTERED";
-        }
-                    
-        for(std::vector<std::string>::iterator fieldIter = fields.begin(); fieldIter != fields.end(); ++fieldIter){
-            if( fieldIter != fields.begin() )
-                resultVcf<< "\t";
-            resultVcf << (*fieldIter);
-        }
-        resultVcf << "\n";
+      if (delSNPIter != methylation.end()) {
+        variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
+      } else if (homoIter != errorProneSNP.end()) {
+        variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
+      } else {
+        variantIter++;
+      }
     }
-}
-
-bool SnpParser::findSNP(std::string chr, int position){
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter = chrVariant->find(chr);
-    // empty chromosome
-    if( chrIter == chrVariant->end() )
-        return false;
-    
-    std::map<int, RefAlt>::iterator posIter = (*chrVariant)[chr].find(position);
-    // empty position
-    if( posIter == (*chrVariant)[chr].end() )
-        return false;
-        
-    return true;
-}
-
-void SnpParser::filterSNP(std::string chr, std::vector<ReadVariant> &readVariantVec, std::string &chr_reference){
-    
-    // pos, <allele, <strand, True>
-    std::map<int, std::map<int, std::map<int, bool> > > posAlleleStrand;
-    std::map< int, bool > methylation;
-    
-    /*
-    // iter all variant, record the strand contained in each SNP
-    for( auto readSNPVecIter : readVariantVec ){
-        // tag allele on forward or reverse strand
-        for(auto variantIter : readSNPVecIter.variantVec ){
-            posAlleleStrand[variantIter.position][variantIter.allele][readSNPVecIter.is_reverse] = true;
-        }
-    }
-    
-    // iter all SNP, both alleles that require SNP need to appear in the two strand
-    for(auto pos: posAlleleStrand){
-        // this position contain two allele, REF allele appear in the two strand, ALT allele appear in the two strand
-        if(pos.second.size() == 2 && pos.second[0].size() == 2 && pos.second[1].size() == 2 ){
-            // high confident SNP
-        }
-        else{
-            //methylation[pos.first] = true;
-        }
-    }
-    */
-
-    // Filter SNPs that are not easy to phasing due to homopolymer
-    // get variant list
-    std::map<std::string, std::map<int, RefAlt> >::iterator chrIter =  chrVariant->find(chr);
-    std::map< int, bool > errorProneSNP;
-    
-    if( chrIter != chrVariant->end() ){
-        std::map<int, int> consecutiveAllele;
-        // iter all SNP and tag homopolymer
-        for(std::map<int, RefAlt>::iterator posIter = (*chrIter).second.begin(); posIter != (*chrIter).second.end(); posIter++ ){
-            consecutiveAllele[(*posIter).first] = homopolymerLength((*posIter).first, chr_reference);
-        }
-        std::map<int, RefAlt>::iterator currSNPIter = (*chrIter).second.begin();
-        std::map<int, RefAlt>::iterator nextSNPIter = std::next(currSNPIter,1);
-        // check whether each SNP pair falls in an area that is not easy to phasing
-        while( currSNPIter != (*chrIter).second.end() && nextSNPIter != (*chrIter).second.end() ){
-            int currPos = (*currSNPIter).first;
-            int nextPos = (*nextSNPIter).first;
-            // filter one of SNP if this SNP pair falls in homopolymer and distance<=2
-            if( consecutiveAllele[currPos] >= 3 && consecutiveAllele[nextPos] >= 3 && std::abs(currPos-nextPos)<=2 ){
-                errorProneSNP[nextPos]=true;
-                nextSNPIter = (*chrIter).second.erase(nextSNPIter);
-                continue;
-            }
-            
-            currSNPIter++;
-            nextSNPIter++;
-        }
-        
-    }
-    
-    // iter all reads
-    for( std::vector<ReadVariant>::iterator readSNPVecIter = readVariantVec.begin() ; readSNPVecIter != readVariantVec.end() ; readSNPVecIter++ ){
-        // iter all SNPs in this read
-        for(std::vector<Variant>::iterator variantIter = (*readSNPVecIter).variantVec.begin() ; variantIter != (*readSNPVecIter).variantVec.end() ; ){
-            std::map< int, bool >::iterator delSNPIter = methylation.find((*variantIter).position);
-            std::map< int, bool >::iterator homoIter = errorProneSNP.find((*variantIter).position);
-            
-            if( delSNPIter != methylation.end() ){
-                variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
-            }
-            else if( homoIter != errorProneSNP.end() ){
-                variantIter = (*readSNPVecIter).variantVec.erase(variantIter);
-            }
-            else{
-                variantIter++;
-            }
-        }
-    }
+  }
 }
 
 // SV
-SVParser::SVParser(PhasingParameters &in_params, SnpParser &in_snpFile):commandLine(false){
-    params = &in_params;
-    snpFile = &in_snpFile;
-    
-    chrVariant = new std::map<std::string, std::map<int, std::map<int ,bool> > >;
-    
-    if( params->svFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressParser(params->svFile);
-    }
-    else if( params->svFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressParser(params->svFile);
-    }
+SVParser::SVParser(PhasingParameters &in_params, SnpParser &in_snpFile) {
+  params = &in_params;
+  snpFile = &in_snpFile;
 
-    // erase SV pos if this pos appear two or more times
-    for(std::map<std::string, std::map<int, bool> >::iterator chrIter = posDuplicate.begin(); chrIter != posDuplicate.end() ; chrIter++){
-        for(std::map<int, bool>::iterator posIter = (*chrIter).second.begin() ; posIter != (*chrIter).second.end() ; posIter++ ){
-            if( (*posIter).second == true){
-                std::map<int, std::map<int ,bool> >::iterator erasePosIter = (*chrVariant)[(*chrIter).first].find((*posIter).first);
-                if(erasePosIter != (*chrVariant)[(*chrIter).first].end()){
-                    (*chrVariant)[(*chrIter).first].erase(erasePosIter);
-                }
-            }
+  chrVariant = new std::map<std::string, std::map<int, std::map<int, bool>>>;
+
+  if (params->svFile.find("gz") != std::string::npos) {
+    // .vcf.gz
+    compressParser(params->svFile);
+  } else if (params->svFile.find("vcf") != std::string::npos) {
+    // .vcf
+    unCompressParser(params->svFile);
+  }
+
+  // erase SV pos if this pos appear two or more times
+  for (std::map<std::string, std::map<int, bool>>::iterator chrIter =
+           posDuplicate.begin();
+       chrIter != posDuplicate.end(); chrIter++) {
+    for (std::map<int, bool>::iterator posIter = (*chrIter).second.begin();
+         posIter != (*chrIter).second.end(); posIter++) {
+      if ((*posIter).second == true) {
+        std::map<int, std::map<int, bool>>::iterator erasePosIter =
+            (*chrVariant)[(*chrIter).first].find((*posIter).first);
+        if (erasePosIter != (*chrVariant)[(*chrIter).first].end()) {
+          (*chrVariant)[(*chrIter).first].erase(erasePosIter);
         }
+      }
     }
+  }
+
 }
 
-SVParser::~SVParser(){ 
-    delete chrVariant;
-}
+SVParser::~SVParser() { delete chrVariant; }
 
-void SVParser::parserProcess(std::string &input){
-    if( input.substr(0, 2) == "##" ){
-
-    }
-    else if ( input.substr(0, 1) == "#" ){
-        
-    }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
-
-        if( fields.size() == 0 )
-            return;
-        // trans to 0-base
-        int pos = std::stoi( fields[1] ) - 1;
-        std::string chr = fields[0];
-                
-        // find GT flag
-        int colon_pos = 0;
-        int gt_pos = fields[8].find("GT");
-        for(int i =0 ; i< gt_pos ; i++){
-            if(fields[8][i]==':')
-                colon_pos++;
-        }
-        // find GT value start
-        int current_colon = 0;
-        int modify_start = 0;
-        for(unsigned int i =0; i < fields[9].length() ; i++){
-            if( current_colon >= colon_pos )
-                break;
-            if(fields[9][i]==':')
-                current_colon++;  
-            modify_start++;
-        }
-        bool filter = false;
-                
-        // homo GT
-        if(fields[9][modify_start]==fields[9][modify_start+2]){
-            filter = true;
-        }
-        // conflict pos with SNP
-        if( (*snpFile).findSNP(chr,pos) ){
-            filter = true;
-        }
-                
-        std::map<int, bool>::iterator posIter = posDuplicate[chr].find(pos);
-        // conflict pos with SV
-        if( posIter == posDuplicate[chr].end() )
-            posDuplicate[chr][pos] = false;
-        else{
-            posDuplicate[chr][pos] = true;
-            filter = true;
-        }
-                
-        if(filter){
-            return;
-        }
-        
-        // get read INFO
-        int start = std::stoi(fields[1]);
-        std::string info = fields[7];
-        size_t svlenPos = info.find("SVLEN=");
-        if (svlenPos != std::string::npos)
-        {
-            svlenPos += 6;
-            size_t semiPos = info.find(';', svlenPos);
-            int svlen = std::stoi(info.substr(svlenPos, semiPos - svlenPos));
-            (*chrVariant)[chr][start][svlen] = true;
-        }
-    }
-}
-
-std::map<int, std::map<int ,bool> > SVParser::getVariants(std::string chrName){
-    std::map<int, std::map<int ,bool> > targetVariants;
-    std::map<std::string, std::map<int, std::map<int ,bool> > >::iterator chrIter = chrVariant->find(chrName);
-    
-    if( chrIter != chrVariant->end() )
-        targetVariants = (*chrIter).second;
-        
-    return targetVariants;
-}
-
-void SVParser::writeResult(PhasingResult phasingResult){
-    
-    if( params->svFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressInput(params->svFile, params->resultPrefix+"_SV.vcf", phasingResult);
-    }
-    else if( params->svFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressInput(params->svFile, params->resultPrefix+"_SV.vcf", phasingResult);
-    }
+void SVParser::parserProcess(std::string &input) {
+  if (input.substr(0, 1) == "#")
     return;
+
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
+
+  if (fields.size() == 0)
+    return;
+  int pos = std::stoi(fields[1]) - 1;
+  int start = std::stoi(fields[1]);
+  std::string chr = fields[0];
+
+  int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+  bool filter = false;
+
+  // homo GT
+  if (fields[9][modify_start] == fields[9][modify_start + 2]) {
+    filter = true;
+  }
+  // conflict pos with SNP
+  if ((*snpFile).findSNP(chr, pos)) {
+    filter = true;
+  }
+
+  std::map<int, bool>::iterator posIter = posDuplicate[chr].find(pos);
+  // conflict pos with SV
+  if (posIter == posDuplicate[chr].end())
+    posDuplicate[chr][pos] = false;
+  else {
+    posDuplicate[chr][pos] = true;
+    filter = true;
+  }
+
+  if (filter) {
+    return;
+  }
+
+  // get read INFO
+  std::string info = fields[7];
+  size_t svlenPos = info.find("SVLEN=");
+  if (svlenPos != std::string::npos) {
+    svlenPos += 6;
+    size_t semiPos = info.find(';', svlenPos);
+    int svlen = std::stoi(info.substr(svlenPos, semiPos - svlenPos));
+  (*chrVariant)[chr][start][svlen] = true;
+  }
 }
 
-void SVParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
-    // header
-    if( input.substr(0, 2) == "##" ){
-        // avoid double definition
-        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
-            ps_def = true;
-        }
-        resultVcf << input << "\n";
-    }
-    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
-        // format line 
-        if( commandLine == false ){
-            if(ps_def == false){
-                resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
-                ps_def = true;
-            }
-            resultVcf << "##longphaseVersion=" << params->version << "\n";
-            resultVcf << "##commandline=\"" << params->command << "\"\n";
-            commandLine = true;
-        }
-        resultVcf << input << "\n";
-    }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+std::map<int, std::map<int, bool>> SVParser::getVariants(std::string chrName) {
+  std::map<int, std::map<int, bool>> targetVariants;
+  std::map<std::string, std::map<int, std::map<int, bool>>>::iterator chrIter =
+      chrVariant->find(chrName);
 
-        std::string chr = fields[0];
+  if (chrIter != chrVariant->end())
+    targetVariants = (*chrIter).second;
 
-        if( fields.size() == 0 )
-            return;
-
-        int pos = std::stoi( fields[1] );
-        int posIdx = pos - 1 ;
-        std::string key = fields[0] + "_" + std::to_string(posIdx);
-
-        PhasingResult::iterator psElementIter =  phasingResult.find(key);
-                
-        // PS flag already exist, erase PS info
-        if( fields[8].find("PS")!= std::string::npos ){
-
-            // find PS flag
-            int colon_pos = 0;
-            int ps_pos = fields[8].find("PS");
-            for(int i =0 ; i< ps_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-                            
-            // erase PS flag
-            if( fields[8].find(":",ps_pos+1) != std::string::npos ){
-                fields[8].erase(ps_pos, 3);
-            }
-            else{
-                fields[8].erase(ps_pos - 1, 3);
-            }
-                        
-            // find PS value start
-            int current_colon = 0;
-            int ps_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                ps_start++;
-            }
-                        
-            // erase PS value
-            if( fields[9].find(":",ps_start+1) != std::string::npos ){
-                int ps_end_pos = fields[9].find(":",ps_start+1);
-                fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
-            }
-            else{
-                fields[9].erase(ps_start-1, fields[9].length() - ps_start + 1);
-            }
-        }
-        // reset GT flag
-        if( fields[8].find("GT")!= std::string::npos ){
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            if(fields[9][modify_start+1] == '|'){
-                // direct modify GT value
-                if(fields[9][modify_start] > fields[9][modify_start+2]){
-                    fields[9][modify_start+1] = fields[9][modify_start];
-                    fields[9][modify_start] = fields[9][modify_start+2];
-                    fields[9][modify_start+2] =fields[9][modify_start+1];
-                }
-                fields[9][modify_start+1] = '/';
-            }        
-        }
-        
-        // Check if the variant is extracted from this VCF
-        auto posIter = (*chrVariant)[fields[0]].find(posIdx + 1);
-        
-        // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
-                    
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
-                    
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            // direct modify GT value
-            fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
-            fields[9][modify_start+1] = '|';
-            fields[9][modify_start+2] = (*psElementIter).second.RAstatus[2];
-        }
-        // this pos has not been phased
-        else{
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":.";
-        }
-        for(std::vector<std::string>::iterator fieldIter = fields.begin(); fieldIter != fields.end(); ++fieldIter){
-            if( fieldIter != fields.begin() )
-                resultVcf<< "\t";
-            resultVcf << (*fieldIter);
-        }
-        resultVcf << "\n";
-    }
-}
-bool SVParser::findSV(std::string chr, int position){
-    std::map<std::string, std::map<int, std::map<int ,bool> > >::iterator chrIter = chrVariant->find(chr);
-    // empty chromosome
-    if( chrIter == chrVariant->end() )
-        return false;
-    
-    std::map<int, std::map<int ,bool>>::iterator posIter = (*chrVariant)[chr].find(position);
-    // empty position
-    if( posIter == (*chrVariant)[chr].end() )
-        return false;
-        
-    return true;
-}
-BamParser::BamParser(std::string inputChrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile, const std::string &ref_string):chrName(inputChrName),BamFileVec(inputBamFileVec){
-    
-    currentVariants = new std::map<int, RefAlt>;
-    currentSV = new std::map<int, std::map<int ,bool> >;
-    currentMod = new std::map<int, std::map<std::string ,RefAlt> >;
-    
-    // use chromosome to find recorded snp map
-    //(*currentVariants) = snpMap.getVariants(chrName);
-    (*currentVariants) = snpMap.getVariants_markindel(chrName, ref_string);
-    // set skip variant start iterator
-    firstVariantIter = currentVariants->begin();
-    if( firstVariantIter == currentVariants->end() ){
-        std::cerr<< "error chromosome name or empty map.\n";
-        exit(1);
-    }
-    // set current chromosome SV map
-    (*currentSV) = svFile.getVariants(chrName);
-    for (const auto &chrPair : *currentSV) {
-        int start = chrPair.first;
-        for (const auto &endPair : chrPair.second) {
-            int end = endPair.first;
-            SV_map[chrName].emplace_back(start, end);
-        }
-    }
-    firstSVIter = SV_map[chrName].begin();
-    // set current chromosome MOD map
-    (*currentMod) = modFile.getVariants(chrName);
-    firstModIter = currentMod->begin();
+  return targetVariants;
 }
 
-BamParser::~BamParser(){
-    delete currentVariants;
-    delete currentSV;
-    delete currentMod;
+void SVParser::writeResult(PhasingResult phasingResult) {
+  dispatchWriteResult(params->svFile, params->resultPrefix + "_SV.vcf",
+                      phasingResult);
 }
 
-void BamParser::direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, ClipCount &clipCount, const std::string &ref_string){
-    
-    // record SNP start iter
-    std::map<int, RefAlt>::iterator tmpFirstVariantIter = firstVariantIter;
-    // record SV start iter
-    std::vector<std::pair<int, int>>::iterator tmpFirstSVIter = firstSVIter;
-    // record MOD start iter
-    std::map<int, std::map<std::string ,RefAlt> >::iterator tmpFirstModIter = firstModIter;
-    
-    for( auto bamFile: BamFileVec ){
-        
-        firstVariantIter = tmpFirstVariantIter;
-        firstSVIter = tmpFirstSVIter;
-        firstModIter = tmpFirstModIter;
+void SVParser::writeDataLine(const std::string &input,
+                               std::ofstream &resultVcf,
+                               PhasingResult &phasingResult) {
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
 
-        // open bam file
-        samFile *fp_in = hts_open(bamFile.c_str(),"r"); 
-        // load reference file
-        hts_set_fai_filename(fp_in, params.fastaFile.c_str() );
-        // read header
-        bam_hdr_t *bamHdr = sam_hdr_read(fp_in); 
-        // initialize an alignment
-        bam1_t *aln = bam_init1(); 
-        hts_idx_t *idx = NULL;
-        
-        if ((idx = sam_index_load(fp_in, bamFile.c_str())) == 0) {
-            std::cout<<"ERROR: Cannot open index for bam file\n";
-            exit(1);
-        }
-        
-        std::string range = chrName + ":1-" + std::to_string(lastSNPPos);
-        hts_itr_t* iter = sam_itr_querys(idx, bamHdr, range.c_str());
+  if (fields.size() == 0)
+    return;
 
-        
-        hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
-        int result;
-        while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) { 
-            int flag = aln->core.flag;
+  int pos = std::stoi(fields[1]);
+  int posIdx = pos - 1;
+  std::string key = fields[0] + "_" + std::to_string(posIdx);
 
-            if (    aln->core.qual < params.mappingQuality  // mapping quality
-                 || (flag & 0x4)   != 0  // read unmapped
-                 || (flag & 0x100) != 0  // secondary alignment. repeat. 
-                                         // A secondary alignment occurs when a given read could align reasonably well to more than one place.
-                 || (flag & 0x400) != 0  // duplicate 
-                 // (flag & 0x800) != 0  // supplementary alignment
-                                         // A chimeric alignment is represented as a set of linear alignments that do not have large overlaps.
-                 ){
-                continue;
-            }
+  PhasingResult::iterator psElementIter = phasingResult.find(key);
 
-            get_snp(*bamHdr, *aln, readVariantVec, clipCount, ref_string, params.isONT, params.svWindow, params.svThreshold);
-        }
-        hts_idx_destroy(idx);
-        bam_hdr_destroy(bamHdr);
-        bam_destroy1(aln);
-        sam_close(fp_in);
+  // PS flag already exist, erase PS info
+  if (fields[8].find("PS") != std::string::npos) {
+    std::string format_before_ps_erase = fields[8];
+    int ps_pos = fields[8].find("PS");
+
+    // erase PS flag
+    if (fields[8].find(":", ps_pos + 1) != std::string::npos) {
+      fields[8].erase(ps_pos, 3);
+    } else {
+      fields[8].erase(ps_pos - 1, 3);
     }
-    
+
+    int ps_start = findFieldValueStart(format_before_ps_erase, fields[9], "PS");
+
+    // erase PS value
+    if (fields[9].find(":", ps_start + 1) != std::string::npos) {
+      int ps_end_pos = fields[9].find(":", ps_start + 1);
+      fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
+    } else {
+      fields[9].erase(ps_start - 1, fields[9].length() - ps_start + 1);
+    }
+  }
+  // reset GT flag
+  if (fields[8].find("GT") != std::string::npos) {
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    if (fields[9][modify_start + 1] == '|') {
+      // direct modify GT value
+      if (fields[9][modify_start] > fields[9][modify_start + 2]) {
+        fields[9][modify_start + 1] = fields[9][modify_start];
+        fields[9][modify_start] = fields[9][modify_start + 2];
+        fields[9][modify_start + 2] = fields[9][modify_start + 1];
+      }
+      fields[9][modify_start + 1] = '/';
+    }
+  }
+
+  // Check if the variant is extracted from this VCF
+  auto posIter = (*chrVariant)[fields[0]].find(posIdx + 1);
+
+  // this pos is phase and exist in map
+  if (psElementIter != phasingResult.end() &&
+      posIter != (*chrVariant)[fields[0]].end()) {
+
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] =
+        fields[9] + ":" + std::to_string((*psElementIter).second.block);
+
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    // direct modify GT value
+    fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
+    fields[9][modify_start + 1] = '|';
+    fields[9][modify_start + 2] = (*psElementIter).second.RAstatus[2];
+  }
+  // this pos has not been phased
+  else {
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] = fields[9] + ":.";
+  }
+  for (std::vector<std::string>::iterator fieldIter = fields.begin();
+       fieldIter != fields.end(); ++fieldIter) {
+    if (fieldIter != fields.begin())
+      resultVcf << "\t";
+    resultVcf << (*fieldIter);
+  }
+  resultVcf << "\n";
 }
 
-void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, ClipCount &clipCount, const std::string &ref_string, bool isONT, int svWindow, double svThreshold){
+bool SVParser::findSV(std::string chr, int position) {
+  std::map<std::string, std::map<int, std::map<int, bool>>>::iterator chrIter =
+      chrVariant->find(chr);
+  // empty chromosome
+  if (chrIter == chrVariant->end())
+    return false;
 
-    ReadVariant *tmpReadResult = new ReadVariant();
-    (*tmpReadResult).read_name = bam_get_qname(&aln);
-    (*tmpReadResult).source_id = bamHdr.target_name[aln.core.tid];
-    (*tmpReadResult).reference_start = aln.core.pos;
-    (*tmpReadResult).is_reverse = bam_is_rev(&aln);
-    
-    // position relative to reference
-    int ref_pos = aln.core.pos;
+  std::map<int, std::map<int, bool>>::iterator posIter =
+      (*chrVariant)[chr].find(position);
+  // empty position
+  if (posIter == (*chrVariant)[chr].end())
+    return false;
 
-    // position relative to read
-    int query_pos = 0;
-    
-    // Skip variants that are to the left of this read
-    while( firstVariantIter != currentVariants->end() && (*firstVariantIter).first < ref_pos )
-        firstVariantIter++;
-    
-    // Skip structure variants that are to the left of this read
-    while( firstSVIter != SV_map[chrName].end() && (*firstSVIter).first < ref_pos )
-        firstSVIter++;
-    
-    // Skip modify that are to the left of this read
-    while( firstModIter != currentMod->end() && (*firstModIter).first < ref_pos )
-        firstModIter++;
+  return true;
+}
+BamParser::BamParser(std::string inputChrName,
+                     std::vector<std::string> inputBamFileVec,
+                     SnpParser &snpMap, SVParser &svFile, METHParser &modFile,
+                     const std::string &ref_string)
+    : chrName(inputChrName), BamFileVec(inputBamFileVec) {
 
-    // set variant start for current alignment
-    std::map<int, RefAlt>::iterator currentVariantIter = firstVariantIter;
-    
-    // set structure variant start for current alignment
-    std::vector<std::pair<int, int>>::iterator currentSVIter = firstSVIter;
-    std::vector<std::pair<int, int>>::iterator previousSVIter = currentSVIter;
-     
-    // set modify start for current alignment
-    std::map<int, std::map<std::string ,RefAlt> >::iterator currentModIter = firstModIter;
+  currentVariants = new std::map<int, SnpVariant>;
+  currentSV = new std::map<int, std::map<int, bool>>;
+  currentMod = new std::map<int, std::map<std::string, ModVariant>>;
 
-    // set cigar pointer and number of cigar
-    uint32_t *cigar = bam_get_cigar(&aln);
-    int aln_core_n_cigar = aln.core.n_cigar;
-    
-    // reading cigar to detect varaint on this read
-    for(int i = 0; i < aln_core_n_cigar ; i++ ){
-        
-        // get current cigar type and cigar length
-        int cigar_op = bam_cigar_op(cigar[i]);
-        int cigar_oplen = bam_cigar_oplen(cigar[i]);
-        
-        // get the starting position of each variant currently.
-        // Use INT_MAX as sentinel when iterator reaches end(), to avoid dereferencing
-        // end() (undefined behavior) and to ensure exhausted variant types never "win"
-        // the min-position comparison in the processing loop below.
-        int modPos = (currentModIter != currentMod->end()) ? (*currentModIter).first : INT_MAX;
-        int svPos = (currentSVIter != SV_map[chrName].end()) ? (*currentSVIter).first - 1 : INT_MAX; // -1: convert 1-based to 0-based coordinate
-        int variantPos = (currentVariantIter != currentVariants->end()) ? (*currentVariantIter).first : INT_MAX;
-        
-        // get the first variant detected by the alignment.
-        while( currentVariantIter != currentVariants->end() && variantPos < ref_pos ){
-            currentVariantIter++;
-            if (currentVariantIter != currentVariants->end()) {
-                variantPos = (*currentVariantIter).first;
-            }
+  initSnpVariants(snpMap, ref_string);
+  initSvVariants(svFile);
+  initModVariants(modFile);
+}
+
+BamParser::~BamParser() {
+  delete currentVariants;
+  delete currentSV;
+  delete currentMod;
+}
+
+void BamParser::initSnpVariants(SnpParser &snpMap, const std::string &ref_string) {
+  // use chromosome to find recorded snp map
+  (*currentVariants) = snpMap.getVariants_markindel(chrName, ref_string);
+  // set skip variant start iterator
+  firstVariantIter = currentVariants->begin();
+  if (firstVariantIter == currentVariants->end()) {
+    std::cerr << "error chromosome name or empty map: " << chrName << "\n";
+    exit(1);
+  }
+}
+
+void BamParser::initSvVariants(SVParser &svFile) {
+  // set current chromosome SV map
+  (*currentSV) = svFile.getVariants(chrName);
+  for (const auto &chrPair : *currentSV) {
+    int start = chrPair.first;
+    for (const auto &endPair : chrPair.second) {
+      int svlen = endPair.first;
+      SV_map[chrName].emplace_back(start, svlen);
+    }
+  }
+  firstSVIter = SV_map[chrName].begin();
+}
+
+void BamParser::initModVariants(METHParser &modFile) {
+  // set current chromosome MOD map
+  (*currentMod) = modFile.getVariants(chrName);
+  firstModIter = currentMod->begin();
+}
+
+bool BamParser::isValidAlignment(const bam1_t &aln, int mappingQuality) {
+  // Intentionally different from modcall/haplotag filters: parameterized qual
+  // threshold; supplementary (0x800) alignments are kept for phasing evidence.
+  int flag = aln.core.flag;
+  return !(aln.core.qual < mappingQuality // mapping quality
+           || (flag & 0x4) != 0           // read unmapped
+           || (flag & 0x100) != 0         // secondary alignment. repeat.
+                                          // A secondary alignment occurs when a
+                                          // given read could align reasonably
+                                          // well to more than one place.
+           || (flag & 0x400) != 0         // duplicate
+           // (flag & 0x800) != 0         // supplementary alignment
+           // A chimeric alignment is represented as a set of linear alignments
+           // that do not have large overlaps.
+  );
+}
+
+void BamParser::direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool,
+                                      PhasingParameters params,
+                                      std::vector<ReadVariant> &readVariantVec,
+                                      ClipCount &clipCount,
+                                      const std::string &ref_string) {
+
+  // record SNP start iter
+  std::map<int, SnpVariant>::iterator tmpFirstVariantIter = firstVariantIter;
+  // record SV start iter
+  std::vector<std::pair<int, int>>::iterator tmpFirstSVIter = firstSVIter;
+  // record MOD start iter
+  std::map<int, std::map<std::string, ModVariant>>::iterator tmpFirstModIter =
+      firstModIter;
+
+  for (auto bamFile : BamFileVec) {
+
+    firstVariantIter = tmpFirstVariantIter;
+    firstSVIter = tmpFirstSVIter;
+    firstModIter = tmpFirstModIter;
+
+    processBamFile(bamFile, lastSNPPos, threadPool, params, readVariantVec,
+                   clipCount, ref_string);
+  }
+}
+
+void BamParser::processBamFile(const std::string &bamFile, int lastSNPPos,
+                                htsThreadPool &threadPool,
+                                const PhasingParameters &params,
+                                std::vector<ReadVariant> &readVariantVec,
+                                ClipCount &clipCount,
+                                const std::string &ref_string) {
+  // open bam file
+  samFile *fp_in = hts_open(bamFile.c_str(), "r");
+  // load reference file
+  hts_set_fai_filename(fp_in, params.fastaFile.c_str());
+  // read header
+  bam_hdr_t *bamHdr = sam_hdr_read(fp_in);
+  // initialize an alignment
+  bam1_t *aln = bam_init1();
+  hts_idx_t *idx = NULL;
+
+  if ((idx = sam_index_load(fp_in, bamFile.c_str())) == 0) {
+    std::cout << "ERROR: Cannot open index for bam file\n";
+    exit(1);
+  }
+
+  std::string range = chrName + ":1-" + std::to_string(lastSNPPos);
+  hts_itr_t *iter = sam_itr_querys(idx, bamHdr, range.c_str());
+
+  hts_set_opt(fp_in, HTS_OPT_THREAD_POOL, &threadPool);
+  int result;
+  while ((result = sam_itr_multi_next(fp_in, iter, aln)) >= 0) {
+    if (!isValidAlignment(*aln, params.mappingQuality)) {
+      continue;
+    }
+
+      get_snp(*bamHdr, *aln, readVariantVec, clipCount, ref_string,
+            params.isONT, params.svWindow, params.svThreshold);
+  }
+  hts_idx_destroy(idx);
+  bam_hdr_destroy(bamHdr);
+  bam_destroy1(aln);
+  sam_close(fp_in);
+}
+
+// Returns true if get_snp() should return immediately (read bounds exceeded).
+bool BamParser::handleDeletionHomopolymerSNP(
+    const bam1_t &aln, int ref_pos, int query_pos, int del_len,
+    const std::string &ref_string,
+    std::map<int, SnpVariant>::iterator &currentVariantIter,
+    ReadVariant &tmpReadResult) {
+
+  if (ref_pos + del_len + 1 == (*currentVariantIter).first) {
+    return false;
+  } else if ((*currentVariantIter).first >= ref_pos &&
+             (*currentVariantIter).first < ref_pos + del_len) {
+    // check snp in homopolymer
+    if (homopolymerLength((*currentVariantIter).first, ref_string) >= 3) {
+      int refAlleleLen = (*currentVariantIter).second.Ref.length();
+      int altAlleleLen = (*currentVariantIter).second.Alt.length();
+      int base_q = 0;
+
+      if (query_pos + 1 > aln.core.l_qseq) {
+        return true;
+      }
+
+      int allele = -1;
+      // SNP
+      if (refAlleleLen == 1 && altAlleleLen == 1) {
+        // get the next match
+        char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
+        if (base == (*currentVariantIter).second.Ref[0]) {
+          allele = 0;
+        } else if (base == (*currentVariantIter).second.Alt[0]) {
+          allele = 1;
         }
-        
-        // Processing the region covered by the current CIGAR operator
-        // Determine if any variant is included in the current CIGAR operator
-        while( ( currentModIter     != currentMod->end()      && modPos     < ref_pos + cigar_oplen ) || 
-               ( currentSVIter      != SV_map[chrName].end()       && svPos      < ref_pos + cigar_oplen ) || 
-               ( currentVariantIter != currentVariants->end() && variantPos < ref_pos + cigar_oplen )){
-            
-            // modification's position is minimal (or equal, MOD takes priority)
-            if( ( currentVariantIter == currentVariants->end() || modPos <= variantPos ) &&
-                ( currentSVIter      == SV_map[chrName].end()       || modPos <= svPos ) &&
-                  currentModIter     != currentMod->end() ){
-                
-                // check this read contain modification
-                std::map<std::string ,RefAlt>::iterator readIter = (*currentModIter).second.find(bam_get_qname(&aln));
-                if( readIter != (*currentModIter).second.end() && modPos <= variantPos ){
-                    
-                    // check varaint strand in vcf file is same as bam file
-                    if( (*readIter).second.is_reverse == bam_is_rev(&aln) ){
-                        // -2 : forward strand
-                        // -3 : reverse strand
-                        int strand = ( bam_is_rev(&aln) ? -3 : -2);
-                        int allele = ((*readIter).second.is_modify ? 0 : 1) ;
-                        Variant *tmpVariant = new Variant(modPos, allele, strand, VariantType::MOD);
-                        // push mod into result vector
-                        (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                        delete tmpVariant;
-                    }
-                }
-                currentModIter++;
-                if (currentModIter != currentMod->end()) {
-                    modPos = (*currentModIter).first;
-                } else {
-                    modPos = INT_MAX;
-                }
-            }
-            // SV's position is minimal (or equal to SNP, SV takes priority over SNP)
-            else if( ( currentVariantIter == currentVariants->end() || svPos <= variantPos ) &&
-                     ( currentModIter     == currentMod->end()      || svPos < modPos ) &&
-                       currentSVIter      != SV_map[chrName].end()){
-                // If this read not contain SV, it means this read is the same as reference genome.
-                // default this read the same as ref
-                
-                int allele = 0;
-                int sv_start = (*currentSVIter).first;
-                int sv_length = (*currentSVIter).second;
-                int sv_end = sv_start + std::abs(sv_length);
-                double sv_region = sv_end - sv_start + 1;
+        base_q = bam_get_qual(&aln)[query_pos];
+      }
+      // the read deletion contain VCF's deletion
+      else if (refAlleleLen != 1 && altAlleleLen == 1) {
+        allele = 1;
+        // using this quality to identify indel
+        base_q = -4;
+      }
 
-                // this read contains SV.
-                int window_size = svWindow;
-                double threshold = svThreshold;
-                for(int j = std::max(i - window_size, 0); j < std::min(i + window_size, aln_core_n_cigar); j++){
-                    int cigar_op = bam_cigar_op(cigar[j]);
-                    int cigar_oplen = bam_cigar_oplen(cigar[j]);
-                    if (cigar_op == BAM_CINS && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < threshold) {
-                        allele = 1;
-                        break;
-                    }
-                    if (cigar_op == BAM_CDEL && std::abs(sv_region - cigar_oplen) / std::abs(sv_region) < threshold) {
-                        allele = 1;
-                        break;
-                    }
-                }
-                
-                // use quality -1 to identify SVs
-                // push this SV to vector
-                Variant *tmpVariant = new Variant(svPos, allele, -1, VariantType::SV);
-                (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                delete tmpVariant;
-                // next SV iter
-                previousSVIter = currentSVIter;
-                currentSVIter++;
-                if (currentSVIter != SV_map[chrName].end()) {
-                    svPos = (*currentSVIter).first - 1;
-                } else {
-                    svPos = INT_MAX;
-                }
-            }
+      if (allele != -1) {
+        tmpReadResult.variantVec.push_back(
+            Variant((*currentVariantIter).first, allele, base_q,
+                    VariantType::SNP));
+        currentVariantIter++;
+      }
+    }
+  }
+  return false;
+}
 
-            // SNP's position is minimal
-            else if( ( currentSVIter      == SV_map[chrName].end()  || variantPos < svPos ) &&
-                     ( currentModIter     == currentMod->end() || variantPos < modPos ) &&
-                       currentVariantIter != currentVariants->end() ){
-                
-                // CIGAR operators: MIDNSHP=X correspond 012345678
-                // 0: alignment match (can be a sequence match or mismatch)
-                // 7: sequence match
-                // 8: sequence mismatch                
-                if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
-                    int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                    int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                    int offset = variantPos - ref_pos;
-                    int base_q = 0;
-                    int allele = -1;
-                    
-                    // The position of the variant exceeds the length of the read.
-                    if( query_pos + offset + 1 > int(aln.core.l_qseq) ){
-                        return;
-                    }
+void BamParser::handleSNPVariant(
+    const bam1_t &aln, int cigar_idx, int cigar_oplen,
+    int ref_pos, int query_pos,
+    std::map<int, SnpVariant>::iterator &currentVariantIter,
+    int &variantPos, ReadVariant &tmpReadResult) {
 
-                    // SNP
-                    if( refAlleleLen == 1 && altAlleleLen == 1){
-                        char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos + offset)];
-                        if(base == (*currentVariantIter).second.Ref[0])
-                            allele = 0;
-                        else if(base == (*currentVariantIter).second.Alt[0])
-                            allele = 1;
+  const uint32_t *cigar = bam_get_cigar(&aln);
+  int aln_core_n_cigar = aln.core.n_cigar;
+  int refAlleleLen = (*currentVariantIter).second.Ref.length();
+  int altAlleleLen = (*currentVariantIter).second.Alt.length();
+  int offset = variantPos - ref_pos;
+  int base_q = 0;
+  int allele = -1;
 
-                        base_q = bam_get_qual(&aln)[query_pos + offset];
-                    } 
-            
-                    // insertion
-                    //if( refAlleleLen == 1 && altAlleleLen != 1 && align.op[i+1] == 1 && i+1 < align.cigar_len){
-                    if( refAlleleLen == 1 && altAlleleLen != 1 && i+1 < aln_core_n_cigar){
-                
-                        // currently, qseq conversion is not performed. Below is the old method for obtaining insertion sequence.
-                
-                        // uint8_t *qstring = bam_get_seq(aln); 
-                        // qseq[i] = seq_nt16_str[bam_seqi(qstring,i)]; 
-                        // std::string prevIns = ( align.op[i-1] == 1 ? qseq.substr(prev_query_pos, align.ol[i-1]) : "" );
+  // SNP
+  if (refAlleleLen == 1 && altAlleleLen == 1) {
+    char base =
+        seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos + offset)];
+    if (base == (*currentVariantIter).second.Ref[0])
+      allele = 0;
+    else if (base == (*currentVariantIter).second.Alt[0])
+      allele = 1;
+    base_q = bam_get_qual(&aln)[query_pos + offset];
+  }
+  // insertion
+  else if (refAlleleLen == 1 && altAlleleLen != 1 &&
+           cigar_idx + 1 < aln_core_n_cigar) {
+    if (ref_pos + cigar_oplen - 1 == variantPos &&
+        bam_cigar_op(cigar[cigar_idx + 1]) == 1) {
+      allele = 1;
+    } else {
+      allele = 0;
+    }
+    // using this quality to identify indel
+    base_q = -4;
+    // using this quality to identify danger indel
+    if ((*currentVariantIter).second.is_danger) {
+      base_q = -5;
+    }
+  }
+  // deletion
+  else if (refAlleleLen != 1 && altAlleleLen == 1 &&
+           cigar_idx + 1 < aln_core_n_cigar) {
+    if (ref_pos + cigar_oplen - 1 == variantPos &&
+        bam_cigar_op(cigar[cigar_idx + 1]) == 2) {
+      allele = 1;
+    } else {
+      allele = 0;
+    }
+    // using this quality to identify indel
+    base_q = -4;
+    // using this quality to identify danger indel
+    if ((*currentVariantIter).second.is_danger) {
+      base_q = -5;
+    }
+  }
 
-                        if ( ref_pos + cigar_oplen - 1 == variantPos && bam_cigar_op(cigar[i+1]) == 1 ) {
-                            allele = 1 ;
-                        }
-                        else {
-                            allele = 0 ;
-                        }
-                        // using this quality to identify indel
-                        base_q = -4;
+  if (allele != -1) {
+    // record snp result
+    tmpReadResult.variantVec.push_back(
+        Variant(variantPos, allele, base_q, VariantType::SNP));
+  }
+  currentVariantIter++;
+  if (currentVariantIter != currentVariants->end()) {
+    variantPos = (*currentVariantIter).first;
+  } else {
+    variantPos = INT_MAX;
+  }
+}
 
-                        // using this quality to identify danger indel
-                        if ( (*currentVariantIter).second.is_danger ) {
-                            base_q = -5 ;
-                        }
-                    } 
-            
-                    // deletion
-                    //if( refAlleleLen != 1 && altAlleleLen == 1 && align.op[i+1] == 2 && i+1 < align.cigar_len){
-                    if( refAlleleLen != 1 && altAlleleLen == 1 && i+1 < aln_core_n_cigar) {
+void BamParser::handleModVariant(
+    const bam1_t &aln, int variantPos,
+    std::map<int, std::map<std::string, ModVariant>>::iterator &currentModIter,
+    int &modPos, ReadVariant &tmpReadResult) {
 
-                        if ( ref_pos + cigar_oplen - 1 == variantPos && bam_cigar_op(cigar[i+1]) == 2 ) {
-                            allele = 1 ;
-                        }
-                        else {
-                            allele = 0 ;
-                        }
-                        // using this quality to identify indel
-                        base_q = -4;
+  std::map<std::string, ModVariant>::iterator readIter =
+      (*currentModIter).second.find(bam_get_qname(&aln));
+  if (readIter != (*currentModIter).second.end() &&
+      modPos <= variantPos) {
+    // check variant strand in vcf file is same as bam file
+    if ((*readIter).second.is_reverse == bam_is_rev(&aln)) {
+      // -2 : forward strand
+      // -3 : reverse strand
+      int strand = (bam_is_rev(&aln) ? -3 : -2);
+      int allele = ((*readIter).second.is_modify ? 0 : 1);
+      // push mod into result vector
+      tmpReadResult.variantVec.push_back(
+          Variant(modPos, allele, strand, VariantType::MOD));
+    }
+  }
+  currentModIter++;
+  if (currentModIter != currentMod->end()) {
+    modPos = (*currentModIter).first;
+  } else {
+    modPos = INT_MAX;
+  }
+}
 
-                        // using this quality to identify danger indel
-                        if ( (*currentVariantIter).second.is_danger ) {
-                            base_q = -5 ;
-                        }
-                    } 
-            
-                    if( allele != -1 ){
-                        // record snp result
-                        Variant *tmpVariant = new Variant(variantPos, allele, base_q, VariantType::SNP);
-                        (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                        delete tmpVariant;                        
-                    }
-                    currentVariantIter++;
-                    if (currentVariantIter != currentVariants->end()) {
-                        variantPos = (*currentVariantIter).first;
-                    } else {
-                        variantPos = INT_MAX;
-                    }
-                }
-                else break;
-            }
-        }
-        
-        // Preparing to process the next CIGAR operator.
-        
+void BamParser::handleSVVariant(
+    const bam1_t &aln, int cigar_i, int svWindow, double svThreshold,
+    std::vector<std::pair<int, int>>::iterator &currentSVIter, int &svPos,
+    ReadVariant &tmpReadResult) {
+
+  const uint32_t *cigar = bam_get_cigar(&aln);
+  int aln_core_n_cigar = aln.core.n_cigar;
+
+  int allele = 0;
+  int sv_start = (*currentSVIter).first;
+  int sv_length = (*currentSVIter).second;
+  int sv_end = sv_start + std::abs(sv_length);
+  double sv_region = sv_end - sv_start + 1;
+
+  for (int j = std::max(cigar_i - svWindow, 0);
+       j < std::min(cigar_i + svWindow, aln_core_n_cigar); j++) {
+    int op = bam_cigar_op(cigar[j]);
+    int oplen = bam_cigar_oplen(cigar[j]);
+    if (op == BAM_CINS &&
+        std::abs(sv_region - oplen) / std::abs(sv_region) < svThreshold) {
+      allele = 1;
+      break;
+    }
+    if (op == BAM_CDEL &&
+        std::abs(sv_region - oplen) / std::abs(sv_region) < svThreshold) {
+      allele = 1;
+      break;
+    }
+  }
+
+  // use quality -1 to identify SVs
+  tmpReadResult.variantVec.push_back(
+      Variant(svPos, allele, -1, VariantType::SV));
+  currentSVIter++;
+  if (currentSVIter != SV_map[chrName].end()) {
+    svPos = (*currentSVIter).first - 1;
+  } else {
+    svPos = INT_MAX;
+  }
+}
+
+void BamParser::get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln,
+                        std::vector<ReadVariant> &readVariantVec,
+                        ClipCount &clipCount, const std::string &ref_string,
+                        bool isONT, int svWindow, double svThreshold) {
+
+  ReadVariant tmpReadResult;
+  tmpReadResult.read_name = bam_get_qname(&aln);
+  tmpReadResult.source_id = bamHdr.target_name[aln.core.tid];
+  tmpReadResult.reference_start = aln.core.pos;
+  tmpReadResult.is_reverse = bam_is_rev(&aln);
+
+  // position relative to reference
+  int ref_pos = aln.core.pos;
+
+  // position relative to read
+  int query_pos = 0;
+
+  // Skip variants that are to the left of this read
+  while (firstVariantIter != currentVariants->end() &&
+         (*firstVariantIter).first < ref_pos)
+    firstVariantIter++;
+
+  // Skip structure variants that are to the left of this read
+  while (firstSVIter != SV_map[chrName].end() && (*firstSVIter).first < ref_pos)
+    firstSVIter++;
+
+  // Skip modify that are to the left of this read
+  while (firstModIter != currentMod->end() && (*firstModIter).first < ref_pos)
+    firstModIter++;
+
+  // set variant start for current alignment
+  std::map<int, SnpVariant>::iterator currentVariantIter = firstVariantIter;
+
+  // set structure variant start for current alignment
+  std::vector<std::pair<int, int>>::iterator currentSVIter = firstSVIter;
+
+  // set modify start for current alignment
+  std::map<int, std::map<std::string, ModVariant>>::iterator currentModIter =
+      firstModIter;
+
+  // set cigar pointer and number of cigar
+  uint32_t *cigar = bam_get_cigar(&aln);
+  int aln_core_n_cigar = aln.core.n_cigar;
+
+  // reading cigar to detect varaint on this read
+  for (int i = 0; i < aln_core_n_cigar; i++) {
+
+    // get current cigar type and cigar length
+    int cigar_op = bam_cigar_op(cigar[i]);
+    int cigar_oplen = bam_cigar_oplen(cigar[i]);
+
+    // get the starting position of each variant currently.
+    // Use INT_MAX as sentinel when iterator reaches end(), to avoid
+    // dereferencing end() (undefined behavior) and to ensure exhausted variant
+    // types never "win" the min-position comparison in the processing loop
+    // below.
+    int modPos = (currentModIter != currentMod->end()) ? (*currentModIter).first
+                                                       : INT_MAX;
+    int svPos =
+        (currentSVIter != SV_map[chrName].end()) ? (*currentSVIter).first - 1
+                                                 : INT_MAX;
+    int variantPos = (currentVariantIter != currentVariants->end())
+                         ? (*currentVariantIter).first
+                         : INT_MAX;
+
+    // Advance currentVariantIter past any variants to the left of ref_pos.
+    // NOTE (Problem⑤): This pre-advance exists only for currentVariantIter.
+    // currentSVIter and currentModIter do not have a corresponding pre-advance
+    // because SV and MOD variants are handled differently in the processing loop:
+    // SV uses a window scan that tolerates stale positions, and MOD relies on a
+    // qname lookup rather than positional ordering. The asymmetry is intentional.
+    while (currentVariantIter != currentVariants->end() &&
+           variantPos < ref_pos) {
+      currentVariantIter++;
+      if (currentVariantIter != currentVariants->end()) {
+        variantPos = (*currentVariantIter).first;
+      }
+    }
+
+    // Processing the region covered by the current CIGAR operator
+    // Determine if any variant is included in the current CIGAR operator
+    while ((currentModIter != currentMod->end() &&
+            modPos < ref_pos + cigar_oplen) ||
+           (currentSVIter != SV_map[chrName].end() &&
+            svPos < ref_pos + cigar_oplen) ||
+           (currentVariantIter != currentVariants->end() &&
+            variantPos < ref_pos + cigar_oplen)) {
+
+      // modification's position is minimal (or equal, MOD takes priority)
+      if ((currentVariantIter == currentVariants->end() ||
+           modPos <= variantPos) &&
+          (currentSVIter == SV_map[chrName].end() || modPos <= svPos) &&
+          currentModIter != currentMod->end()) {
+
+        handleModVariant(aln, variantPos, currentModIter, modPos, tmpReadResult);
+      }
+      // SV's position is minimal (or equal to SNP, SV takes priority over SNP)
+      else if ((currentVariantIter == currentVariants->end() ||
+                svPos <= variantPos) &&
+               (currentModIter == currentMod->end() || svPos < modPos) &&
+               currentSVIter != SV_map[chrName].end()) {
+        // If this read not contain SV, it means this read is the same as
+        // reference genome. default this read the same as ref
+
+        handleSVVariant(aln, i, svWindow, svThreshold, currentSVIter, svPos, tmpReadResult);
+      }
+
+      // SNP's position is minimal
+      else if ((currentSVIter == SV_map[chrName].end() || variantPos < svPos) &&
+               (currentModIter == currentMod->end() || variantPos < modPos) &&
+               currentVariantIter != currentVariants->end()) {
+
         // CIGAR operators: MIDNSHP=X correspond 012345678
         // 0: alignment match (can be a sequence match or mismatch)
         // 7: sequence match
         // 8: sequence mismatch
-        if( cigar_op == 0 || cigar_op == 7 || cigar_op == 8 ){
-            query_pos += cigar_oplen;
-            ref_pos += cigar_oplen;
-        }
-        // 1: insertion to the reference
-        else if( cigar_op == 1 ){
-            query_pos += cigar_oplen;
-        }
-        else if( cigar_op == 2 ){
-            
-            // If a reference is given
-            // it will determine whether the SNP falls in the homopolymer
-            // and start the processing of the SNP fall in the alignment GAP
-            if(ref_string != ""){
-                int del_len = cigar_oplen;
-                if ( ref_pos + del_len + 1 == (*currentVariantIter).first ){
-                    //if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
-                        // special case
-                    //}
-                }
-                else if( (*currentVariantIter).first >= ref_pos  && (*currentVariantIter).first < ref_pos + del_len ){
-                    // check snp in homopolymer
-                    if( homopolymerLength((*currentVariantIter).first , ref_string) >=3 ){
-                        
-                        int refAlleleLen = (*currentVariantIter).second.Ref.length();
-                        int altAlleleLen = (*currentVariantIter).second.Alt.length();
-                        int base_q = 0;  
-                        
-                        if( query_pos + 1 > aln.core.l_qseq ){
-                            return;
-                        }
-
-                        int allele = -1;
-                        // SNP
-                        if( refAlleleLen == 1 && altAlleleLen == 1){
-                            // get the next match
-                            char base = seq_nt16_str[bam_seqi(bam_get_seq(&aln), query_pos)];
-                            if( base == (*currentVariantIter).second.Ref[0] ){
-                                allele = 0;
-                            }
-                            else if( base == (*currentVariantIter).second.Alt[0] ){
-                                allele = 1;
-                            }
-                            base_q = bam_get_qual(&aln)[query_pos];
-                        }
-                        // the read deletion contain VCF's deletion
-                        else if( refAlleleLen != 1 && altAlleleLen == 1 ){
-
-                            if( refAlleleLen != 1 && altAlleleLen == 1){
-                                //std::string delSeq = ref_string.substr(ref_pos - 1, align.ol[i] + 1);
-                                //std::string refSeq = (*currentVariantIter).second.Ref;
-                                //std::string altSeq = (*currentVariantIter).second.Alt;
-
-                                allele = 1;
-                                // using this quality to identify indel
-                                base_q = -4;
-                            }
-                            else if ( allele == -1 ) {
-                                allele = 0;
-                                // using this quality to identify indel
-                                base_q = -4;
-                            }
-                            
-                        }
-                        
-                        if(allele != -1){
-                            Variant *tmpVariant = new Variant((*currentVariantIter).first, allele, base_q, VariantType::SNP);
-                            (*tmpReadResult).variantVec.push_back( (*tmpVariant) );
-                            currentVariantIter++;
-                            delete tmpVariant;
-                        }
-
-                    }
-                }
-            }
-            ref_pos += cigar_oplen;
-        }
-        // 3: skipped region from the reference
-        else if( cigar_op == 3 ){
-            ref_pos += cigar_oplen;
-        }
-        // 4: soft clipping (clipped sequences present in SEQ)
-        else if( cigar_op == 4 ){
-            query_pos += cigar_oplen;
-            getClip(ref_pos, i, cigar_oplen, clipCount);
-        }
-        // 5: hard clipping (clipped sequences NOT present in SEQ)
-	    else if( cigar_op == 5 ){
-            getClip(ref_pos, i, cigar_oplen, clipCount);
-        }
-	    // 6: padding (silent deletion from padded reference)
-	    else if(cigar_op == 6 ){
-
-        }
-        else{
-            std::cerr<< "alignment find unsupported CIGAR operation from read: " << bam_get_qname(&aln) << "\n";
-            exit(1);
-        }
+        if (cigar_op == 0 || cigar_op == 7 || cigar_op == 8) {
+          int offset = variantPos - ref_pos;
+          // The position of the variant exceeds the length of the read.
+          if (query_pos + offset + 1 > int(aln.core.l_qseq)) {
+            return;
+          }
+          handleSNPVariant(aln, i, cigar_oplen, ref_pos, query_pos,
+                           currentVariantIter, variantPos, tmpReadResult);
+        } else
+          break;
+      }
     }
 
-    if( (*tmpReadResult).variantVec.size() > 0 )
-      readVariantVec.push_back((*tmpReadResult));
-    delete tmpReadResult;
+    // Preparing to process the next CIGAR operator.
+
+    // CIGAR operators: MIDNSHP=X correspond 012345678
+    // 0: alignment match (can be a sequence match or mismatch)
+    // 7: sequence match
+    // 8: sequence mismatch
+    if (cigar_op == 0 || cigar_op == 7 || cigar_op == 8) {
+      query_pos += cigar_oplen;
+      ref_pos += cigar_oplen;
+    }
+    // 1: insertion to the reference
+    else if (cigar_op == 1) {
+      query_pos += cigar_oplen;
+    } else if (cigar_op == 2) {
+      // If a reference is given, check whether any SNP falls in a homopolymer
+      // region spanned by this deletion and handle it specially.
+      if (ref_string != "") {
+        if (handleDeletionHomopolymerSNP(aln, ref_pos, query_pos, cigar_oplen,
+                                         ref_string, currentVariantIter,
+                                         tmpReadResult))
+          return;
+      }
+      ref_pos += cigar_oplen;
+    }
+    // 3: skipped region from the reference
+    else if (cigar_op == 3) {
+      ref_pos += cigar_oplen;
+    }
+    // 4: soft clipping (clipped sequences present in SEQ)
+    else if (cigar_op == 4) {
+      query_pos += cigar_oplen;
+      getClip(ref_pos, i, cigar_oplen, clipCount);
+    }
+    // 5: hard clipping (clipped sequences NOT present in SEQ)
+    else if (cigar_op == 5) {
+      getClip(ref_pos, i, cigar_oplen, clipCount);
+    }
+    // 6: padding (silent deletion from padded reference)
+    else if (cigar_op == 6) {
+
+    } else {
+      std::cerr << "alignment find unsupported CIGAR operation from read: "
+                << bam_get_qname(&aln) << "\n";
+      exit(1);
+    }
+  }
+
+  if (tmpReadResult.variantVec.size() > 0) {
+    readVariantVec.push_back(tmpReadResult);
+  }
 }
 
-void BamParser::getClip(int pos, int clipFrontBack, int len, ClipCount &clipCount){
-    if (len > 5){
-        if (clipFrontBack == FRONT){
-            clipCount[pos][FRONT]++;
-        }
-        else {
-            clipCount[pos][BACK]++;
-        }
+void BamParser::getClip(int pos, int clipFrontBack, int len,
+                        ClipCount &clipCount) {
+  if (len > 5) {
+    if (clipFrontBack == FRONT) {
+      clipCount[pos][FRONT]++;
+    } else {
+      clipCount[pos][BACK]++;
     }
+  }
 }
 
-METHParser::METHParser(PhasingParameters &in_params, SnpParser &in_snpFile, SVParser &in_svFile):commandLine(false){
-	params = &in_params;
-    snpFile = &in_snpFile;
-    svFile = &in_svFile;
-    representativePos=-1;
-    upMethPos = -1;
-    
-    chrVariant = new std::map<std::string, std::map<int, std::map<std::string ,RefAlt> > >;
-    representativeMap = new std::map<int, int >;
-    
-    if( params->modFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressParser(params->modFile);
-    }
-    else if( params->modFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressParser(params->modFile);
-    }
+METHParser::METHParser(PhasingParameters &in_params, SnpParser &in_snpFile,
+                       SVParser &in_svFile) {
+  params = &in_params;
+  snpFile = &in_snpFile;
+  svFile = &in_svFile;
+  representativePos = -1;
+  upMethPos = -1;
+
+  chrVariant = new std::map<std::string,
+                            std::map<int, std::map<std::string, ModVariant>>>;
+  representativeMap = new std::map<int, int>;
+
+  if (params->modFile.find("gz") != std::string::npos) {
+    // .vcf.gz
+    compressParser(params->modFile);
+  } else if (params->modFile.find("vcf") != std::string::npos) {
+    // .vcf
+    unCompressParser(params->modFile);
+  }
 }
 
-void METHParser::writeResult(PhasingResult phasingResult){
-    
-    if( params->modFile.find("gz") != std::string::npos ){
-        // .vcf.gz 
-        compressInput(params->modFile, params->resultPrefix+"_mod.vcf", phasingResult);
-    }
-    else if( params->modFile.find("vcf") != std::string::npos ){
-        // .vcf
-        unCompressInput(params->modFile, params->resultPrefix+"_mod.vcf", phasingResult);
-    }
+void METHParser::writeResult(PhasingResult phasingResult) {
+  dispatchWriteResult(params->modFile, params->resultPrefix + "_mod.vcf",
+                      phasingResult);
+}
+
+METHParser::~METHParser() {
+  delete chrVariant;
+  delete representativeMap;
+}
+
+void METHParser::parserProcess(std::string &input) {
+  if (input[0] == '#')
     return;
+
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
+
+  if (fields.size() == 0) {
+    return;
+  }
+
+  // trans 1-base position to 0-base
+  int pos = std::stoi(fields[1]) - 1;
+  std::string chr = fields[0];
+
+  // In a series of consecutive methylation positions,
+  // the first methylation position will be used as the representative after
+  // merging.
+  if (upMethPos + 1 != pos) {
+    representativePos = pos;
+  }
+
+  int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+
+  // homo GT
+  if (fields[9][modify_start] == fields[9][modify_start + 2]) {
+    return;
+  }
+
+  // conflict pos with SNP and SV
+  if ((*snpFile).findSNP(chr, pos) || (*svFile).findSV(chr, pos)) {
+    return;
+  }
+
+  bool is_reverse;
+  // get strand
+  if (fields[7].find("RS=P") != std::string::npos) {
+    is_reverse = false;
+  } else if (fields[7].find("RS=N") != std::string::npos) {
+    is_reverse = true;
+  } else {
+    return;
+  }
+
+  // parse MR and NR reads
+  parseReadList(fields[7], "MR=", chr, representativePos, is_reverse, true,  *chrVariant);
+  parseReadList(fields[7], "NR=", chr, representativePos, is_reverse, false, *chrVariant);
+
+  // Record the positions corresponding to the current representative position
+  (*representativeMap)[pos] = representativePos;
+  upMethPos = pos;
 }
 
-METHParser::~METHParser(){
-	delete chrVariant;
-    delete representativeMap;
-}
+void METHParser::writeDataLine(const std::string &input,
+                                   std::ofstream &resultVcf,
+                                   PhasingResult &phasingResult) {
+  std::istringstream iss(input);
+  std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),
+                                  std::istream_iterator<std::string>());
 
-void METHParser::parserProcess(std::string &input){
-    // header
-    if( input.substr(0, 1) != "#" ){
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+  if (fields.size() == 0)
+    return;
 
-        if( fields.size() == 0 ){
-            return;
-        }
-        
-        // trans 1-base position to 0-base
-        int pos = std::stoi( fields[1] ) - 1;
-        std::string chr = fields[0];
-                
-        // find GT flag
-        int colon_pos = 0;
-        int gt_pos = fields[8].find("GT");
-        for(int i =0 ; i< gt_pos ; i++){
-            if(fields[8][i]==':')
-                colon_pos++;
-        }
-        
-        // In a series of consecutive methylation positions, 
-        // the first methylation position will be used as the representative after merging.
-        if( upMethPos + 1 != pos ){
-            representativePos = pos;
-        }
-        
-        // find GT value start
-        int current_colon = 0;
-        int modify_start = 0;
-        for(unsigned int i =0; i < fields[9].length() ; i++){
-            if( current_colon >= colon_pos )
-                break;
-            if(fields[9][i]==':')
-                current_colon++;  
-            modify_start++;
-        }
-       
-        // homo GT
-        if(fields[9][modify_start]==fields[9][modify_start+2]){
-            return;
-        }
-        
-        // conflict pos with SNP and SV
-        if( (*snpFile).findSNP(chr,pos) || (*svFile).findSV(chr,pos) ){
-            return;
-        }
-        
-        bool is_reverse;
-        // get strand
-        if(fields[7].find("RS=P") != std::string::npos){
-            is_reverse = false;
-        }
-        else if(fields[7].find("RS=N") != std::string::npos){
-            is_reverse = true;
-        }
-        else{
-            return;
-        }
-        
-        // parse MR and NR reads
-        // get modification reads (MR) INFO
-        int read_pos = fields[7].find("MR=");
-        read_pos = fields[7].find("=",read_pos);
-        read_pos++;
-                
-        int next_field = fields[7].find(";",read_pos);
-        std::string totalRead = fields[7].substr(read_pos,next_field-read_pos);
-        std::stringstream totalMonReadStream(totalRead);
-        
-        // Extract the reads in the MR string. These reads contain methylation.
-        std::string read;
-        while(std::getline(totalMonReadStream, read, ',')){
-            RefAlt tmp;
-            tmp.is_reverse = is_reverse;
-            tmp.is_modify = true;
-            (*chrVariant)[chr][representativePos][read]= tmp;
-        }
-        
-        // get nonmodification reads (NR) INFO
-        read_pos = fields[7].find("NR=");
-        read_pos = fields[7].find("=",read_pos);
-        read_pos++;
-        
-        next_field = fields[7].find(";",read_pos);
-        totalRead = fields[7].substr(read_pos,next_field-read_pos);
-        std::stringstream totalnonModReadStream(totalRead);
-        
-        // Extract the reads in the NR string. These reads not contain methylation.
-        while(std::getline(totalnonModReadStream, read, ',')){
-            RefAlt tmp;
-            tmp.is_reverse = is_reverse;
-            tmp.is_modify = false;
-            (*chrVariant)[chr][representativePos][read]= tmp;
-        }
-        
-        // Record the positions corresponding to the current representative position
-        (*representativeMap)[pos]= representativePos;  
-        upMethPos = pos;
+  int pos = std::stoi(fields[1]);
+  // use current position to find representative position
+  int posIdx = (*representativeMap)[pos - 1];
+
+  std::string key = fields[0] + "_" + std::to_string(posIdx);
+
+  PhasingResult::iterator psElementIter = phasingResult.find(key);
+
+  // PS flag already exist, erase PS info
+  if (fields[8].find("PS") != std::string::npos) {
+
+    std::string format_before_ps_erase = fields[8];
+
+    // erase PS flag
+    int ps_pos = fields[8].find("PS");
+    if (fields[8].find(":", ps_pos + 1) != std::string::npos) {
+      fields[8].erase(ps_pos, 3);
+    } else {
+      fields[8].erase(ps_pos - 1, 3);
     }
+
+    // find PS value start
+    int ps_start = findFieldValueStart(format_before_ps_erase, fields[9], "PS");
+
+    // erase PS value
+    if (fields[9].find(":", ps_start + 1) != std::string::npos) {
+      int ps_end_pos = fields[9].find(":", ps_start + 1);
+      fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
+    } else {
+      fields[9].erase(ps_start - 1, fields[9].length() - ps_start + 1);
+    }
+  }
+  // reset GT flag
+  if (fields[8].find("GT") != std::string::npos) {
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    if (fields[9][modify_start + 1] == '|') {
+      // direct modify GT value
+      if (fields[9][modify_start] > fields[9][modify_start + 2]) {
+        fields[9][modify_start + 1] = fields[9][modify_start];
+        fields[9][modify_start] = fields[9][modify_start + 2];
+        fields[9][modify_start + 2] = fields[9][modify_start + 1];
+      }
+      fields[9][modify_start + 1] = '/';
+    }
+  }
+
+  // Check if the variant is extracted from this VCF
+  auto posIter = (*chrVariant)[fields[0]].find(posIdx);
+
+  // this pos is phase and exist in map
+  if (psElementIter != phasingResult.end() &&
+      posIter != (*chrVariant)[fields[0]].end()) {
+
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] =
+        fields[9] + ":" + std::to_string((*psElementIter).second.block);
+
+    int modify_start = findFieldValueStart(fields[8], fields[9], "GT");
+    // direct modify GT value
+    fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
+    fields[9][modify_start + 1] = '|';
+    fields[9][modify_start + 2] = (*psElementIter).second.RAstatus[2];
+  }
+  // this pos has not been phased
+  else {
+    // add PS flag and value
+    fields[8] = fields[8] + ":PS";
+    fields[9] = fields[9] + ":.";
+  }
+  for (std::vector<std::string>::iterator fieldIter = fields.begin();
+       fieldIter != fields.end(); ++fieldIter) {
+    if (fieldIter != fields.begin())
+      resultVcf << "\t";
+    resultVcf << (*fieldIter);
+  }
+  resultVcf << "\n";
 }
 
-void METHParser::writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult){
-    // header
-    if( input.substr(0, 2) == "##" ){
-        // avoid double definition
-        if( input.substr(0, 16) == "##FORMAT=<ID=PS," ){
-            ps_def = true;
-        }
-        resultVcf << input << "\n";
-    }
-    else if ( input.substr(0, 6) == "#CHROM" || input.substr(0, 6) == "#chrom" ){
-        // format line 
-        if( commandLine == false ){
-            if(ps_def == false){
-                resultVcf <<  "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set identifier\">\n";
-                ps_def = true;
-            }
-            resultVcf << "##longphaseVersion=" << params->version << "\n";
-            resultVcf << "##commandline=\"" << params->command << "\"\n";
-            commandLine = true;
-        }
-        resultVcf << input << "\n";
-    }
-    else{
-        std::istringstream iss(input);
-        std::vector<std::string> fields((std::istream_iterator<std::string>(iss)),std::istream_iterator<std::string>());
+std::map<int, std::map<std::string, ModVariant>>
+METHParser::getVariants(std::string chrName) {
+  std::map<int, std::map<std::string, ModVariant>> targetVariants;
+  std::map<std::string,
+           std::map<int, std::map<std::string, ModVariant>>>::iterator chrIter =
+      chrVariant->find(chrName);
 
-        std::string chr = fields[0];
+  if (chrIter != chrVariant->end())
+    targetVariants = (*chrIter).second;
 
-        if( fields.size() == 0 )
-            return;
-
-        int pos = std::stoi( fields[1] );
-        // use current position to find representative position
-        int posIdx = (*representativeMap)[pos - 1];
-        
-        std::string key = fields[0] + "_" + std::to_string(posIdx);
-
-        PhasingResult::iterator psElementIter =  phasingResult.find(key);
-                
-        // PS flag already exist, erase PS info
-        if( fields[8].find("PS")!= std::string::npos ){
-
-            // find PS flag
-            int colon_pos = 0;
-            int ps_pos = fields[8].find("PS");
-            for(int i =0 ; i< ps_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-                            
-            // erase PS flag
-            if( fields[8].find(":",ps_pos+1) != std::string::npos ){
-                fields[8].erase(ps_pos, 3);
-            }
-            else{
-                fields[8].erase(ps_pos - 1, 3);
-            }
-                        
-            // find PS value start
-            int current_colon = 0;
-            int ps_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                ps_start++;
-            }
-                        
-            // erase PS value
-            if( fields[9].find(":",ps_start+1) != std::string::npos ){
-                int ps_end_pos = fields[9].find(":",ps_start+1);
-                fields[9].erase(ps_start, ps_end_pos - ps_start + 1);
-            }
-            else{
-                fields[9].erase(ps_start-1, fields[9].length() - ps_start + 1);
-            }
-        }
-        // reset GT flag
-        if( fields[8].find("GT")!= std::string::npos ){
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            if(fields[9][modify_start+1] == '|'){
-                // direct modify GT value
-                if(fields[9][modify_start] > fields[9][modify_start+2]){
-                    fields[9][modify_start+1] = fields[9][modify_start];
-                    fields[9][modify_start] = fields[9][modify_start+2];
-                    fields[9][modify_start+2] =fields[9][modify_start+1];
-                }
-                fields[9][modify_start+1] = '/';
-            }        
-        }
-        
-        // Check if the variant is extracted from this VCF
-        auto posIter = (*chrVariant)[fields[0]].find(posIdx); 
-        
-        // this pos is phase and exist in map
-        if( psElementIter != phasingResult.end() && posIter != (*chrVariant)[fields[0]].end() ){
-                    
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":" + std::to_string((*psElementIter).second.block);
-                    
-            // find GT flag
-            int colon_pos = 0;
-            int gt_pos = fields[8].find("GT");
-            for(int i =0 ; i< gt_pos ; i++){
-                if(fields[8][i]==':')
-                    colon_pos++;
-            }
-            // find GT value start
-            int current_colon = 0;
-            int modify_start = 0;
-            for(unsigned int i =0; i < fields[9].length() ; i++){
-                if( current_colon >= colon_pos )
-                    break;
-                if(fields[9][i]==':')
-                    current_colon++;  
-                modify_start++;
-            }
-            // direct modify GT value
-            fields[9][modify_start] = (*psElementIter).second.RAstatus[0];
-            fields[9][modify_start+1] = '|';
-            fields[9][modify_start+2] = (*psElementIter).second.RAstatus[2];
-        }
-        // this pos has not been phased
-        else{
-            // add PS flag and value
-            fields[8] = fields[8] + ":PS";
-            fields[9] = fields[9] + ":.";
-        }
-        for(std::vector<std::string>::iterator fieldIter = fields.begin(); fieldIter != fields.end(); ++fieldIter){
-            if( fieldIter != fields.begin() )
-                resultVcf<< "\t";
-            resultVcf << (*fieldIter);
-        }
-        resultVcf << "\n";
-        
-    }
+  return targetVariants;
 }
-
-std::map<int, std::map<std::string ,RefAlt> > METHParser::getVariants(std::string chrName){
-    std::map<int, std::map<std::string ,RefAlt> > targetVariants;
-    std::map<std::string, std::map<int, std::map<std::string ,RefAlt> > >::iterator chrIter = chrVariant->find(chrName);
-    
-    if( chrIter != chrVariant->end() )
-        targetVariants =  (*chrIter).second;
-        
-    return targetVariants;
-}
-

--- a/ParsingBam.h
+++ b/ParsingBam.h
@@ -1,209 +1,261 @@
 #ifndef PARSINGBAM_H
 #define PARSINGBAM_H
 
-#include "Util.h"
+#include "ModCallProcess.h"
 #include "PhasingProcess.h"
-#include <htslib/sam.h>
+#include "Util.h"
 #include <htslib/faidx.h>
-#include <htslib/khash.h>
 #include <htslib/kbitset.h>
+#include <htslib/khash.h>
+#include <htslib/sam.h>
 #include <htslib/thread_pool.h>
 #include <htslib/vcf.h>
 #include <htslib/vcfutils.h>
-#include "ModCallProcess.h"
+#include <functional>
 #include <zlib.h>
 
-struct RefAlt{
-    std::string Ref;
-    std::string Alt;
-    bool is_reverse;
-    bool is_modify;
-    bool is_danger;
+struct SnpVariant {
+  std::string Ref;
+  std::string Alt;
+  bool is_danger = false;
 };
 
-class FastaParser{
-    private:
-        // file name
-        std::string fastaFile ;
-        std::vector<std::string> chrName;
-        std::vector<int> last_pos;
-    public:
-        FastaParser(std::string fastaFile, std::vector<std::string> chrName, std::vector<int> last_pos, int numThreads);
-        ~FastaParser();
-        
-        // chrName, chr string
-        std::map<std::string, std::string > chrString;
-    
-};
-
-class BaseVairantParser{
-    public:
-        // input parser
-        void compressParser(std::string &variantFile);
-        void unCompressParser(std::string &variantFile);
-        virtual void parserProcess(std::string &input)=0;
-        // output parser
-        void compressInput(std::string variantFile, std::string resultFile, PhasingResult phasingResult);
-        void unCompressInput(std::string variantFile, std::string resultFile, PhasingResult phasingResult);
-        virtual void writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult)=0;
-};
-
-class SnpParser : public BaseVairantParser{
-    
-    private:
-        PhasingParameters *params;
-        //std::string variantFile;
-        // chr, variant position (0-base), allele haplotype
-        std::map<std::string, std::map<int, RefAlt> > *chrVariant;
-        // id and idx
-        std::vector<std::string> chrName;
-        // chr, variant position (0-base)
-        std::map<std::string, std::map<int, bool> > chrVariantHomopolymer;
-        
-        // Track the position of filtered indels
-        std::map<std::string, std::set<int> > filteredIndelPositions;
-
-        // log file for filtered indels
-        std::ofstream removedIndelsLog;
-        
-        // override input parser
-        void parserProcess(std::string &input);
-        // override output parser
-        void writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult);
-        
-        bool commandLine;
-        
-    public:
-    
-        SnpParser(PhasingParameters &in_params);
-        ~SnpParser();     
-            
-        std::map<int, RefAlt> getVariants(std::string chrName);  
-
-	    std::map<int, RefAlt> getVariants_markindel(std::string chrName, const std::string &ref);
-
-        std::vector<std::string> getChrVec();
-        
-        bool findChromosome(std::string chrName);
-        
-        int getLastSNP(std::string chrName);
-        
-        void writeResult(PhasingResult phasingResult);
-
-        bool findSNP(std::string chr, int posistion);
-        
-        void filterSNP(std::string chr, std::vector<ReadVariant> &readVariantVec, std::string &chr_reference);
-};
-
-class SVParser : public BaseVairantParser{
-    
-    private:
-        PhasingParameters *params;
-        SnpParser *snpFile;
-
-        // chr , variant position (0-base), read
-        std::map<std::string, std::map<int, std::map<int, bool> > > *chrVariant;
-        // chr, variant position (0-base)
-        std::map<std::string, std::map<int, bool> > posDuplicate;
-        
-        // override input parser
-        void parserProcess(std::string &input);
-        // override output parser
-        void writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult);
-        
-        bool commandLine;
-        
-    public:
-    
-        SVParser(PhasingParameters &params, SnpParser &snpFile);
-        ~SVParser();
-            
-        std::map<int, std::map<int, bool> > getVariants(std::string chrName);
-
-        void writeResult(PhasingResult phasingResult);
-
-        bool findSV(std::string chr, int posistion);
-};
-
-class METHParser : public BaseVairantParser{
-    
-    private:
-        PhasingParameters *params;
-        SnpParser *snpFile;
-        SVParser *svFile;
-        
-        int representativePos;
-        int upMethPos;
-        
-        // chr , variant position (0-base), read, (is reverse strand)
-        std::map<std::string, std::map<int, std::map<std::string ,RefAlt> > > *chrVariant;
-        // In a series of consecutive methylation positions, 
-        // the first methylation position will be used as the representative after merging.
-        // This map is used to find the coordinates that originally represented itself
-        std::map<int, int > *representativeMap;
-
-        // override input parser
-        void parserProcess(std::string &input);
-        // override output parser
-        void writeLine(std::string &input, bool &ps_def, std::ofstream &resultVcf, PhasingResult &phasingResult);
-        
-        bool commandLine;
-        
-    public:
-        
-        std::map<int, std::map<std::string ,RefAlt> > getVariants(std::string chrName);  
-        
-        METHParser(PhasingParameters &params, SnpParser &snpFile, SVParser &svFile);
-        ~METHParser();
-		
-		void writeResult(PhasingResult phasingResult);
-};
-
-struct Alignment{
-    std::string chr;
-    std::string qname;
-    int refStart;
-    int qlen;
-    char *qseq;
-    int cigar_len;
-    int *op;
-    int *ol;
-    char *quality;
-    bool is_reverse;
+struct ModVariant {
+  bool is_reverse = false;
+  bool is_modify = false;
 };
 
 
-enum ClipFrontBack {
-    FRONT = 0,
-    BACK = 1
+class FastaParser {
+private:
+  // file name
+  std::string fastaFile;
+  std::vector<std::string> chrName;
+  std::vector<int> last_pos;
+
+public:
+  FastaParser(std::string fastaFile, std::vector<std::string> chrName,
+              std::vector<int> last_pos, int numThreads);
+  ~FastaParser();
+
+  // chrName, chr string
+  std::map<std::string, std::string> chrString;
 };
+
+class BaseVairantParser {
+public:
+  BaseVairantParser() : params(nullptr), commandLine(false) {}
+  // input parser
+  void compressParser(std::string &variantFile);
+  void unCompressParser(std::string &variantFile);
+  virtual void parserProcess(std::string &input) = 0;
+  // output parser
+  void compressInput(std::string variantFile, std::string resultFile,
+                     PhasingResult phasingResult);
+  void unCompressInput(std::string variantFile, std::string resultFile,
+                       PhasingResult phasingResult);
+  void dispatchWriteResult(const std::string &inputFile,
+                           const std::string &outputFile,
+                           PhasingResult phasingResult);
+  void writeLine(std::string &input, bool &ps_def,
+                 std::ofstream &resultVcf,
+                 PhasingResult &phasingResult);
+
+protected:
+  PhasingParameters *params;
+  bool commandLine;
+  virtual void writeMetaHeader(const std::string &input, bool &ps_def,
+                               std::ofstream &resultVcf);
+  void writeColumnHeader(const std::string &input, bool &ps_def,
+                         std::ofstream &resultVcf);
+  virtual void writeDataLine(const std::string &input,
+                             std::ofstream &resultVcf,
+                             PhasingResult &phasingResult) = 0;
+
+private:
+  void readGzLines(const std::string &variantFile,
+                   std::function<void(const std::string &)> callback);
+};
+
+class SnpParser : public BaseVairantParser {
+
+private:
+  // std::string variantFile;
+  //  chr, variant position (0-base), allele haplotype
+  std::map<std::string, std::map<int, SnpVariant>> *chrVariant;
+  // id and idx
+  std::vector<std::string> chrName;
+  // chr, variant position (0-base)
+  std::map<std::string, std::map<int, bool>> chrVariantHomopolymer;
+
+  // Track the position of filtered indels
+  std::map<std::string, std::set<int>> filteredIndelPositions;
+
+  // override input parser
+  void parserProcess(std::string &input);
+  // override output parser
+  void writeMetaHeader(const std::string &input, bool &ps_def,
+                       std::ofstream &resultVcf);
+  void writeDataLine(const std::string &input, std::ofstream &resultVcf,
+                     PhasingResult &phasingResult);
+
+public:
+  SnpParser(PhasingParameters &in_params);
+  ~SnpParser();
+
+  std::map<int, SnpVariant> getVariants(std::string chrName);
+
+  std::map<int, SnpVariant> getVariants_markindel(std::string chrName,
+                                                  const std::string &ref);
+
+  std::vector<std::string> getChrVec();
+
+  int getLastSNP(std::string chrName);
+
+  void writeResult(PhasingResult phasingResult);
+
+  bool findSNP(std::string chr, int posistion);
+
+  void filterSNP(std::string chr, std::vector<ReadVariant> &readVariantVec,
+                 std::string &chr_reference);
+};
+
+class SVParser : public BaseVairantParser {
+
+private:
+  SnpParser *snpFile;
+
+  // chr , variant position (0-base), read
+  std::map<std::string, std::map<int, std::map<int, bool>>> *chrVariant;
+  // chr, variant position (0-base)
+  std::map<std::string, std::map<int, bool>> posDuplicate;
+
+  // override input parser
+  void parserProcess(std::string &input);
+  // override output parser
+  void writeDataLine(const std::string &input, std::ofstream &resultVcf,
+                     PhasingResult &phasingResult);
+
+public:
+  SVParser(PhasingParameters &params, SnpParser &snpFile);
+  ~SVParser();
+
+  std::map<int, std::map<int, bool>> getVariants(std::string chrName);
+
+  void writeResult(PhasingResult phasingResult);
+
+  bool findSV(std::string chr, int posistion);
+};
+
+class METHParser : public BaseVairantParser {
+
+private:
+  SnpParser *snpFile;
+  SVParser *svFile;
+
+  int representativePos;
+  int upMethPos;
+
+  // chr , variant position (0-base), read, (is reverse strand)
+  std::map<std::string, std::map<int, std::map<std::string, ModVariant>>>
+      *chrVariant;
+  // In a series of consecutive methylation positions,
+  // the first methylation position will be used as the representative after
+  // merging. This map is used to find the coordinates that originally
+  // represented itself
+  std::map<int, int> *representativeMap;
+
+  // override input parser
+  void parserProcess(std::string &input);
+  // override output parser
+  void writeDataLine(const std::string &input, std::ofstream &resultVcf,
+                     PhasingResult &phasingResult);
+
+public:
+  std::map<int, std::map<std::string, ModVariant>>
+  getVariants(std::string chrName);
+
+  METHParser(PhasingParameters &params, SnpParser &snpFile, SVParser &svFile);
+  ~METHParser();
+
+  void writeResult(PhasingResult phasingResult);
+};
+
+struct Alignment {
+  std::string chr;
+  std::string qname;
+  int refStart;
+  int qlen;
+  char *qseq;
+  int cigar_len;
+  int *op;
+  int *ol;
+  char *quality;
+  bool is_reverse;
+};
+
+enum ClipFrontBack { FRONT = 0, BACK = 1 };
 
 // pos<read start|read end ,count >
 using ClipCount = std::map<int, std::map<ClipFrontBack, int>>;
 
-class BamParser{
-    
-    private:
-        std::string chrName;
-        std::vector<std::string> BamFileVec;
-        // SNP map and iter
-        std::map<int, RefAlt> *currentVariants;
-        std::map<int, RefAlt>::iterator firstVariantIter;
-        // SV map and iter
-        std::map<int, std::map<int, bool> > *currentSV;
-        std::vector<std::pair<int, int> >::iterator firstSVIter;
-        std::map<std::string, std::vector<std::pair<int, int> > > SV_map;
-        // mod map and iter
-        std::map<int, std::map<std::string, RefAlt> > *currentMod;
-        std::map<int, std::map<std::string, RefAlt> >::iterator firstModIter;
-        void get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln, std::vector<ReadVariant> &readVariantVec, ClipCount &clipCount, const std::string &ref_string, bool isONT, int svWindow, double svThreshold);
-        void getClip(int pos, int clipFrontBack, int len, ClipCount &clipCount);
+class BamParser {
 
-    public:
-        BamParser(std::string chrName, std::vector<std::string> inputBamFileVec, SnpParser &snpMap, SVParser &svFile, METHParser &modFile, const std::string &ref_string);
-        ~BamParser();
-        
-        void direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool, PhasingParameters params, std::vector<ReadVariant> &readVariantVec, ClipCount &clipCount, const std::string &ref_string);
+private:
+  std::string chrName;
+  std::vector<std::string> BamFileVec;
+  // SNP map and iter
+  std::map<int, SnpVariant> *currentVariants;
+  std::map<int, SnpVariant>::iterator firstVariantIter;
+  // SV map and iter
+  std::map<int, std::map<int, bool>> *currentSV;
+  std::vector<std::pair<int, int>>::iterator firstSVIter;
+  std::map<std::string, std::vector<std::pair<int, int>>> SV_map;
+  // mod map and iter
+  std::map<int, std::map<std::string, ModVariant>> *currentMod;
+  std::map<int, std::map<std::string, ModVariant>>::iterator firstModIter;
+  void initSnpVariants(SnpParser &snpMap, const std::string &ref_string);
+  void initSvVariants(SVParser &svFile);
+  void initModVariants(METHParser &modFile);
+  bool handleDeletionHomopolymerSNP(
+      const bam1_t &aln, int ref_pos, int query_pos, int del_len,
+      const std::string &ref_string,
+      std::map<int, SnpVariant>::iterator &currentVariantIter,
+      ReadVariant &tmpReadResult);
+  void handleSNPVariant(const bam1_t &aln, int cigar_idx, int cigar_oplen,
+                        int ref_pos, int query_pos,
+                        std::map<int, SnpVariant>::iterator &currentVariantIter,
+                        int &variantPos, ReadVariant &tmpReadResult);
+  void handleModVariant(
+      const bam1_t &aln, int variantPos,
+      std::map<int, std::map<std::string, ModVariant>>::iterator &currentModIter,
+      int &modPos, ReadVariant &tmpReadResult);
+  void handleSVVariant(
+      const bam1_t &aln, int cigar_i, int svWindow, double svThreshold,
+      std::vector<std::pair<int, int>>::iterator &currentSVIter, int &svPos,
+      ReadVariant &tmpReadResult);
+  void get_snp(const bam_hdr_t &bamHdr, const bam1_t &aln,
+               std::vector<ReadVariant> &readVariantVec, ClipCount &clipCount,
+               const std::string &ref_string, bool isONT, int svWindow,
+               double svThreshold);
+  void getClip(int pos, int clipFrontBack, int len, ClipCount &clipCount);
+  bool isValidAlignment(const bam1_t &aln, int mappingQuality);
+  void processBamFile(const std::string &bamFile, int lastSNPPos,
+                      htsThreadPool &threadPool, const PhasingParameters &params,
+                      std::vector<ReadVariant> &readVariantVec,
+                      ClipCount &clipCount, const std::string &ref_string);
+
+public:
+  BamParser(std::string chrName, std::vector<std::string> inputBamFileVec,
+            SnpParser &snpMap, SVParser &svFile, METHParser &modFile,
+            const std::string &ref_string);
+  ~BamParser();
+
+  void direct_detect_alleles(int lastSNPPos, htsThreadPool &threadPool,
+                             PhasingParameters params,
+                             std::vector<ReadVariant> &readVariantVec,
+                             ClipCount &clipCount,
+                             const std::string &ref_string);
 };
 
 #endif

--- a/PhasingGraph.cpp
+++ b/PhasingGraph.cpp
@@ -1,4 +1,47 @@
 #include "PhasingGraph.h"
+
+namespace {
+
+void appendDotEdges(std::vector<std::string>& outDotResult, int currPos, const std::pair<PosAllele, PosAllele>& edgePair){
+    std::string refEdge = std::to_string(currPos + 1) + ".1\t->\t" + std::to_string(edgePair.first.first + 1) + "." + std::to_string(edgePair.first.second);
+    std::string altEdge = std::to_string(currPos + 1) + ".2\t->\t" + std::to_string(edgePair.second.first + 1) + "." + std::to_string(edgePair.second.second);
+
+    outDotResult.push_back(refEdge);
+    outDotResult.push_back(altEdge);
+}
+
+void recordVoteForNextPosition(
+    int currHP,
+    int targetPos,
+    int targetHaplotypeRelation,
+    VoteResult& vote,
+    std::map<int, std::map<int, float> >& hpCountMap2,
+    std::map<int, std::vector<VoteResult> >& hpCountMap3){
+    if(currHP == 1){
+        if(targetHaplotypeRelation == 1){
+            hpCountMap2[targetPos][1] += vote.weight;
+            vote.hap = 1;
+        }
+        else if(targetHaplotypeRelation == 2){
+            hpCountMap2[targetPos][2] += vote.weight;
+            vote.hap = 2;
+        }
+    }
+    else if(currHP == 2){
+        if(targetHaplotypeRelation == 1){
+            hpCountMap2[targetPos][2] += vote.weight;
+            vote.hap = 2;
+        }
+        else if(targetHaplotypeRelation == 2){
+            hpCountMap2[targetPos][1] += vote.weight;
+            vote.hap = 1;
+        }
+    }
+
+    hpCountMap3[targetPos].push_back(vote);
+}
+
+}
 //SubEdge
 
 SubEdge::SubEdge():readCount(0){ 
@@ -283,155 +326,99 @@ std::pair<float,float> VairiantGraph::Onelongcase( std::vector<VoteResult> vote 
 }
 
 //VairiantGraph
-void VairiantGraph::edgeConnectResult(){
-    //current variant position, haplotype (1 or 2), previous variants' voting information 
-    std::map<int, std::vector<VoteResult> > *hpCountMap3 = new std::map<int, std::vector<VoteResult> > ;
-    // current variant position, haplotype (1 or 2), previous variants' voting result
-    std::map<int, std::map<int,float> > *hpCountMap2 = new std::map<int, std::map<int,float> > ;
-    // current snp, haplotype (1 or 2), support snp
-    std::map<int, std::map<int,std::vector<int> > > *hpCountMap = new std::map<int, std::map<int,std::vector<int> > >;
-    // current snp, result haplotype (1 or 2)
-    std::map<int,int> *hpResult = new std::map<int,int>;
-    // < block start, <snp in this block> >
-    std::map<int,std::vector<int> > *phasedBlocks = new std::map<int,std::vector<int> >;
-    
+void VairiantGraph::scanVariantsAndBuildBlocks(std::map<int, int>& hpResult, PhasedBlocks& phasedBlocks, std::vector<std::string>& outDotResult){
+    std::map<int, std::vector<VoteResult> > hpCountMap3;
+    std::map<int, std::map<int,float> > hpCountMap2;
     int blockStart = -1;
-    int currPos = -1;
-    int nextPos = -1;
     int lastConnectPos = -1;
 
-    // Visit all position and assign SNPs to haplotype.
-    // Avoid recording duplicate information,
-    // only one of the two alleles needs to be used for each SNP
-    for(std::map<int,ReadBaseMap*>::iterator variantIter = totalVariantInfo->begin() ; variantIter != totalVariantInfo->end() ; variantIter++ ){
-        // check next position
+    for(std::map<int,ReadBaseMap*>::iterator variantIter = totalVariantInfo->begin(); variantIter != totalVariantInfo->end(); variantIter++ ){
         std::map<int,ReadBaseMap*>::iterator nextNodeIter = std::next(variantIter, 1);
-        if( nextNodeIter == totalVariantInfo->end() ){
-             break;
+        if(nextNodeIter == totalVariantInfo->end()){
+            break;
         }
-        
-        currPos = variantIter->first;
-        nextPos = nextNodeIter->first;
-        
-        // There should not be a large distance between any two variants, 
-        // with the default being a distance of 300000bp, equivalent to one centromere length.
-        if(std::abs(nextPos-currPos) > params->distance ){
+
+        int currPos = variantIter->first;
+        int nextPos = nextNodeIter->first;
+
+        if(std::abs(nextPos - currPos) > params->distance){
             continue;
         }
-        
-        // get the number of HP1 and HP2 supported reference allele
-        //int h1 = (*hpCountMap)[currPos][1].size();
-        //int h2 = (*hpCountMap)[currPos][2].size();
-        float h1 = (*hpCountMap2)[currPos][1] ;
-	    float h2 = (*hpCountMap2)[currPos][2] ;
 
-        //std::cout << currPos+1 << "\t" << "h1:" << "\t" << h1 << "\t" << "h2:" << "\t" << h2 << "\n" ;
+        float h1 = hpCountMap2[currPos][1];
+        float h2 = hpCountMap2[currPos][2];
 
-	//Handle the special case which One Long Read provides wrong info repeatedly
-        std::pair<float, float> special = Onelongcase( (*hpCountMap3)[currPos] ) ;
-	    if ( special.first != -1 ) {
-           h1 = special.first ;
-           h2 = special.second ;
+        std::pair<float, float> special = Onelongcase(hpCountMap3[currPos]);
+        if(special.first != -1){
+            h1 = special.first;
+            h2 = special.second;
         }
 
-        // new block, set this position as block start 
-        if( h1 == h2 ){
-            // No new blocks should be created if the next SNP has already been picked up
-            if( currPos < lastConnectPos ){
+        if(h1 == h2){
+            if(currPos < lastConnectPos){
                 continue;
             }
-            
+
             blockStart = currPos;
-            (*phasedBlocks)[blockStart].push_back(currPos);
-            (*hpResult)[currPos] = 1;
+            phasedBlocks[blockStart].push_back(currPos);
+            hpResult[currPos] = 1;
         }
         else{
-            int currHP = ( h1 > h2 ? 1 : 2 );
-            (*hpResult)[currPos] = currHP;
-            (*phasedBlocks)[blockStart].push_back(currPos);
+            int currHP = (h1 > h2 ? 1 : 2);
+            hpResult[currPos] = currHP;
+            phasedBlocks[blockStart].push_back(currPos);
         }
-        // Check if there is no edge from current node
-        std::map<int,VariantEdge*>::iterator edgeIter = edgeList->find( currPos );
-        if( edgeIter==edgeList->end() ){
+
+        std::map<int,VariantEdge*>::iterator edgeIter = edgeList->find(currPos);
+        if(edgeIter == edgeList->end()){
             continue;
         }
-        
-        // check connect between surrent SNP and next n SNPs
-        for(int i = 0 ; i < params->connectAdjacent ; i++ ){
-	    VoteResult vote(currPos, 1); //used to store previous 20 variants' voting information
 
-        // consider reads from the currnt SNP and the next (i+1)'s SNP
-        std::pair<PosAllele,PosAllele> tmp = edgeIter->second->findBestEdgePair(nextNodeIter->first, params->isONT, params->edgeThreshold, false, *variantType, vote);
+        for(int i = 0; i < params->connectAdjacent; i++ ){
+            VoteResult vote(currPos, 1);
+            std::pair<PosAllele,PosAllele> bestEdgePair = edgeIter->second->findBestEdgePair(nextNodeIter->first, params->isONT, params->edgeThreshold, false, *variantType, vote);
 
-	    // if the target is a danger indel change its weight to 0.1
-	    if ( (*variantType)[currPos] == 4 ) {
-                vote.weight = 0.1 ;
+            if((*variantType)[currPos] == 4){
+                vote.weight = 0.1;
             }
 
-            // -1 : no connect  
-            //  1 : the haplotype of next (i+1)'s SNP are same as previous
-            //  2 : the haplotype of next (i+1)'s SNP are different as previous
-            if( tmp.first.second != -1 ){
-                // record the haplotype resut of next (i+1)'s SNP
-                if( (*hpResult)[currPos] == 1 ){
-                    if( tmp.first.second == 1 ){
-                        (*hpCountMap)[nextNodeIter->first][1].push_back(currPos);
-		                (*hpCountMap2)[nextNodeIter->first][1] += vote.weight;
-                        vote.hap = 1 ;
-                    }
-                    if( tmp.first.second == 2 ){
-                        (*hpCountMap)[nextNodeIter->first][2].push_back(currPos);
-		                (*hpCountMap2)[nextNodeIter->first][2] += vote.weight;
-		                vote.hap = 2 ;
-                    }
-                }
-                if( (*hpResult)[currPos]==2 ){
-                    if( tmp.first.second == 1 ){
-                        (*hpCountMap)[nextNodeIter->first][2].push_back(currPos);
-                        (*hpCountMap2)[nextNodeIter->first][2] += vote.weight;
-                        vote.hap = 2 ;
-                    }
-                    if( tmp.first.second == 2 ){
-                        (*hpCountMap)[nextNodeIter->first][1].push_back(currPos);
-                        (*hpCountMap2)[nextNodeIter->first][1] += vote.weight;
-                        vote.hap = 1 ;
-                    }
+            if(bestEdgePair.first.second != -1){
+                recordVoteForNextPosition(
+                    hpResult[currPos],
+                    nextNodeIter->first,
+                    bestEdgePair.first.second,
+                    vote,
+                    hpCountMap2,
+                    hpCountMap3);
+
+                if(params->generateDot){
+                    appendDotEdges(outDotResult, currPos, bestEdgePair);
                 }
 
-                (*hpCountMap3)[nextNodeIter->first].push_back( vote );
-
-                if( params->generateDot ){
-                    std::string e1 = std::to_string(currPos+1) + ".1\t->\t" + std::to_string(tmp.first.first+1) + "." + std::to_string(tmp.first.second);
-                    std::string e2 = std::to_string(currPos+1) + ".2\t->\t" + std::to_string(tmp.second.first+1) + "." + std::to_string(tmp.second.second);
-
-                    dotResult.push_back(e1);
-                    dotResult.push_back(e2);
-                }
-                
                 lastConnectPos = nextNodeIter->first;
             }
+
             nextNodeIter++;
-            if( nextNodeIter == totalVariantInfo->end() ){
+            if(nextNodeIter == totalVariantInfo->end()){
                 break;
             }
         }
     }
+}
 
-    // outFile.close();
-    // loop all block and construct graph
-    // Record the phase set(PS) for each variant on the graph and record the haplotype to each variant's allele belongs.
-    for(auto blockIter = phasedBlocks->begin() ; blockIter != phasedBlocks->end() ; blockIter++ ){
-        // check block size to skip one node island
-        if( (*blockIter).second.size()<=1 ){
+void VairiantGraph::materializeBlockResults(
+    const std::map<int, int>& hpResult,
+    const PhasedBlocks& phasedBlocks,
+    std::map<PosAllele, int>& outBkResult,
+    std::map<PosAllele, int>& outSubNodeHP){
+    for(auto blockIter = phasedBlocks.begin(); blockIter != phasedBlocks.end(); blockIter++ ){
+        if((*blockIter).second.size() <= 1){
             continue;
         }
-        
-        // loop block's node
-        // store phasing results include PS and HP
-        for(auto currIter = (*blockIter).second.begin() ; currIter != (*blockIter).second.end() ; currIter++ ){
-            // check next node
-            auto nextIter = std::next(currIter,1);
-            if( nextIter == (*blockIter).second.end() ){
+
+        for(auto currIter = (*blockIter).second.begin(); currIter != (*blockIter).second.end(); currIter++ ){
+            auto nextIter = std::next(currIter, 1);
+            if(nextIter == (*blockIter).second.end()){
                 continue;
             }
 
@@ -439,38 +426,38 @@ void VairiantGraph::edgeConnectResult(){
             PosAllele altStart = std::make_pair((*currIter), 2);
             PosAllele refEnd = std::make_pair((*nextIter), 1);
             PosAllele altEnd = std::make_pair((*nextIter), 2);
-            
-            // store PS results
-            (*bkResult)[refStart] = (*blockIter).first + 1;
-            (*bkResult)[refEnd]   = (*blockIter).first + 1;
-            (*bkResult)[altStart] = (*blockIter).first + 1;
-            (*bkResult)[altEnd]   = (*blockIter).first + 1;
-            
-            // store HP results
-            if( currIter == (*blockIter).second.begin() ){
-                (*subNodeHP)[refStart] = 0;
-                (*subNodeHP)[altStart] = 1;
+
+            outBkResult[refStart] = (*blockIter).first + 1;
+            outBkResult[refEnd]   = (*blockIter).first + 1;
+            outBkResult[altStart] = (*blockIter).first + 1;
+            outBkResult[altEnd]   = (*blockIter).first + 1;
+
+            if(currIter == (*blockIter).second.begin()){
+                outSubNodeHP[refStart] = 0;
+                outSubNodeHP[altStart] = 1;
             }
-            
-            if( (*hpResult)[(*currIter)] == 0 || (*hpResult)[(*nextIter)] == 0 ){
-                
+
+            if(hpResult.at(*currIter) == 0 || hpResult.at(*nextIter) == 0){
+
             }
-            else if( (*hpResult)[(*currIter)] == (*hpResult)[(*nextIter)] ){
-                (*subNodeHP)[refEnd] = (*subNodeHP)[refStart];
-                (*subNodeHP)[altEnd] = (*subNodeHP)[altStart];
+            else if(hpResult.at(*currIter) == hpResult.at(*nextIter)){
+                outSubNodeHP[refEnd] = outSubNodeHP[refStart];
+                outSubNodeHP[altEnd] = outSubNodeHP[altStart];
             }
             else{
-                (*subNodeHP)[refEnd] = (*subNodeHP)[altStart];
-                (*subNodeHP)[altEnd] = (*subNodeHP)[refStart];
+                outSubNodeHP[refEnd] = outSubNodeHP[altStart];
+                outSubNodeHP[altEnd] = outSubNodeHP[refStart];
             }
         }
     }
-    
-    delete hpCountMap;
-    delete hpCountMap2;
-    delete hpCountMap3;
-    delete hpResult;
-    delete phasedBlocks;
+}
+
+void VairiantGraph::edgeConnectResult(){
+    std::map<int, int> hpResult;
+    PhasedBlocks phasedBlocks;
+
+    scanVariantsAndBuildBlocks(hpResult, phasedBlocks, dotResult);
+    materializeBlockResults(hpResult, phasedBlocks, *bkResult, *subNodeHP);
 }
 
 VairiantGraph::VairiantGraph(std::string &in_ref, PhasingParameters &in_params, std::string &in_chrName){
@@ -691,11 +678,7 @@ void VairiantGraph::filterHighMismatchVariants(std::vector<ReadVariant>& in_read
     }
 }
     
-void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip){
-
-    readVariant = &in_readVariant;
-    std::map<std::string,ReadVariant> mergeReadMap;
-
+void VairiantGraph::filterOverlappingAlignments(std::vector<ReadVariant> &in_readVariant){
     // each read will record first and last variant posistion
     std::map<std::string, std::pair<int,int>> alignRange;
     // record an iterator for all alignments of a read.
@@ -712,57 +695,53 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
         auto& readRange = alignRange[readName];
         auto& readIdxVecRef = readIdxVec[readName];
 
-        // Initialize readRange if it's the first appearance
-        if (alignRange.find(readName) == alignRange.end()) {
-            readRange = {firstVariantPos,lastVariantPos};
-        } else {
-            // Check for overlaps
-            while (readRange.first <= firstVariantPos && firstVariantPos <= readRange.second) {
-                if (lastVariantPos < readRange.second) {
-                    is_toDelete = 1;
-                    delReadIdx.push_back(readIter);
-                    break;
-                }
-
-                int preAlignIdx = readIdxVecRef.size() - 1;
-                if (preAlignIdx < 0 ) break;
-
-                const auto& previousAlignment = in_readVariant[readIdxVecRef[preAlignIdx]];
-                const auto& prevVariantVec = previousAlignment.variantVec;
-                int prevStart = prevVariantVec.front().position;
-                int prevEnd = prevVariantVec.back().position;
-
-                double overlapStart = std::max(prevStart, firstVariantPos);
-                double overlapEnd = std::min(prevEnd, lastVariantPos);
-                if (overlapStart > overlapEnd) break; // No overlap
-                double overlapLen = overlapEnd - overlapStart + 1;
-
-                double alignStart = std::max(prevEnd, lastVariantPos);
-                double alignEnd = std::min(prevStart, firstVariantPos);
-                double alignSpan = alignStart - alignEnd + 1;
-                double overlapRatio = overlapLen / alignSpan;
-
-                // Filtering highly overlapping alignments
-                if (overlapRatio >= params->overlapThreshold) {
-                    int alignLen1 = prevEnd - prevStart + 1;
-                    int alignLen2 = lastVariantPos - firstVariantPos + 1;
-
-                    if (alignLen2 <= alignLen1) {
-                        is_toDelete = 1;
-                        delReadIdx.push_back(readIter); // Current alignment is shorter
-                        break;
-                    } else {
-                        delReadIdx.push_back(readIdxVecRef[preAlignIdx]); // Previous alignment is shorter
-                        readIdxVecRef.pop_back();
-                        readRange.second = (preAlignIdx > 0) ? in_readVariant[readIdxVecRef[preAlignIdx - 1]].variantVec.back().position : firstVariantPos;
-                    }
-                } else {
-                    break;
-                }
+        // On the first appearance, operator[] initializes readRange to {0, 0},
+        // so the overlap condition below naturally does not hold.
+        while (readRange.first <= firstVariantPos && firstVariantPos <= readRange.second) {
+            if (lastVariantPos < readRange.second) {
+                is_toDelete = 1;
+                delReadIdx.push_back(readIter);
+                break;
             }
-            // update range
-            readRange.second = lastVariantPos;
+
+            int preAlignIdx = readIdxVecRef.size() - 1;
+            if (preAlignIdx < 0 ) break;
+
+            const auto& previousAlignment = in_readVariant[readIdxVecRef[preAlignIdx]];
+            const auto& prevVariantVec = previousAlignment.variantVec;
+            int prevStart = prevVariantVec.front().position;
+            int prevEnd = prevVariantVec.back().position;
+
+            double overlapStart = std::max(prevStart, firstVariantPos);
+            double overlapEnd = std::min(prevEnd, lastVariantPos);
+            if (overlapStart > overlapEnd) break; // No overlap
+            double overlapLen = overlapEnd - overlapStart + 1;
+
+            double alignStart = std::max(prevEnd, lastVariantPos);
+            double alignEnd = std::min(prevStart, firstVariantPos);
+            double alignSpan = alignStart - alignEnd + 1;
+            double overlapRatio = overlapLen / alignSpan;
+
+            // Filtering highly overlapping alignments
+            if (overlapRatio >= params->overlapThreshold) {
+                int alignLen1 = prevEnd - prevStart + 1;
+                int alignLen2 = lastVariantPos - firstVariantPos + 1;
+
+                if (alignLen2 <= alignLen1) {
+                    is_toDelete = 1;
+                    delReadIdx.push_back(readIter); // Current alignment is shorter
+                    break;
+                } else {
+                    delReadIdx.push_back(readIdxVecRef[preAlignIdx]); // Previous alignment is shorter
+                    readIdxVecRef.pop_back();
+                    readRange.second = (preAlignIdx > 0) ? in_readVariant[readIdxVecRef[preAlignIdx - 1]].variantVec.back().position : firstVariantPos;
+                }
+            } else {
+                break;
+            }
         }
+        // update range
+        readRange.second = lastVariantPos;
         if (is_toDelete == 0 )
             readIdxVecRef.push_back(readIter);
     }
@@ -779,7 +758,9 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
         }
     }
     in_readVariant.erase( std::next(in_readVariant.begin(), saveIter), in_readVariant.end()); 
-    
+}
+
+void VairiantGraph::applyCnvFilter(std::vector<ReadVariant> &in_readVariant, Clip &clip){
     CnvStatistics cnvStats;
     //calculate the mismatch rate of the cnv
     calculateCnvMismatchRate(in_readVariant, clip);
@@ -789,16 +770,16 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
     calculateAverageMismatchRate(clip, cnvStats.cnvReadMmrate, cnvStats.missRateMap);
     //filter the variants with high mismatch rate
     filterHighMismatchVariants(in_readVariant, clip, cnvStats.missRateMap);
+}
 
-    int readCount=0;
+void VairiantGraph::buildVariantGraph(std::vector<ReadVariant> &in_readVariant){
+    std::map<std::string,ReadVariant> mergeReadMap;
+
     // merge alignment
     for(std::vector<ReadVariant>::iterator readIter = in_readVariant.begin() ; readIter != in_readVariant.end() ; readIter++ ){
- 
-        // Creating a pseudo read which allows filtering out variants that should not be phased
-        //ReadVariant tmpRead;
+
         // Visiting all the variants on the read
         for( auto variant : (*readIter).variantVec ){
-            readCount++;
             // modification
             if( variant.quality == -2 || variant.quality == -3 ){
                 (*variantType)[variant.position] = 2;
@@ -831,8 +812,6 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
                 (*variantType)[variant.position] = 0;
             }
             mergeReadMap[(*readIter).read_name].variantVec.push_back(variant);
-
-            //tmpRead.variantVec.push_back(variant);
             
             // Each position will record the included reads and their corresponding base qualities.
             auto variantIter = totalVariantInfo->find(variant.position);
@@ -840,7 +819,7 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
             if( variantIter == totalVariantInfo->end() ){
                 (*totalVariantInfo)[variant.position] = new ReadBaseMap();
             }
-            
+
             (*(*totalVariantInfo)[variant.position])[(*readIter).read_name] = variant.quality;
         }
     }   
@@ -879,77 +858,69 @@ void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip
         }
 
         //count the ref and alt base amount of the last variant on the read
-	    if ( variant1Iter != (*readIter).second.variantVec.end() && variant2Iter == (*readIter).second.variantVec.end() ) {
+        if ( variant1Iter != (*readIter).second.variantVec.end() && variant2Iter == (*readIter).second.variantVec.end() ) {
             std::map<int,VariantEdge*>::iterator posIter = edgeList->find((*variant1Iter).position);
             if( posIter == edgeList->end() ) {
                 (*edgeList)[(*variant1Iter).position] = new VariantEdge((*variant1Iter).position);
             }
         }
     }
+}
+
+void VairiantGraph::addEdge(std::vector<ReadVariant> &in_readVariant, Clip &clip){
+
+    readVariant = &in_readVariant;
+
+    filterOverlappingAlignments(in_readVariant);
+    applyCnvFilter(in_readVariant, clip);
+    buildVariantGraph(in_readVariant);
+
 } 
 
-void VairiantGraph::readCorrection(){
+void VairiantGraph::accumulateReadHaplotypeEvidence(const Variant& variant, double& refCount, double& altCount){
+    PosAllele refAllele = std::make_pair(variant.position, variant.allele + 1);
+    std::map<PosAllele, int>::iterator nodePS = bkResult->find(refAllele);
 
-    
-    std::map<std::string,std::map<int,std::map<int,int>>> readBlockHP;
-    
-    std::map<std::string,std::map<int,std::map<int,int>>> readBlockHPcount;
-    
-    
-    // haplotype, <position <allele, base count>>
-    std::map<int,std::map<int,std::map<double,double>>> *hpAlleleCountMap = new std::map<int,std::map<int,std::map<double,double>>>;
+    if(nodePS == bkResult->end() || nodePS->second == 0){
+        return;
+    }
 
-    
+    int refHaplotype = (*subNodeHP)[refAllele];
+    int positionVariantType = (*variantType)[variant.position];
+
+    if(positionVariantType == 0 || positionVariantType == 1){
+        if(refHaplotype == 0) refCount++;
+        else altCount++;
+    }
+    else if(positionVariantType == 2){
+        return;
+    }
+    else if(positionVariantType == 3 || positionVariantType == 4){
+        if(refHaplotype == 0) refCount += 0.1;
+        else altCount += 0.1;
+    }
+}
+
+void VairiantGraph::assignReadHaplotypesAndCollectAlleleCounts(HpAlleleCountMap& hpAlleleCountMap){
     // iter all read, determine the haplotype of the read
-    for(std::vector<ReadVariant>::iterator readIter = (*readVariant).begin() ; readIter != (*readVariant).end() ; readIter++ ){
+    for(std::vector<ReadVariant>::iterator readIter = (*readVariant).begin(); readIter != (*readVariant).end(); readIter++){
         double refCount = 0;
         double altCount = 0;
-        //int block;  
-          
-        // loop all variant 
-        for( auto variant : (*readIter).variantVec ){
-            PosAllele refAllele = std::make_pair( variant.position , variant.allele+1);
-            std::map<PosAllele,int>::iterator nodePS = bkResult->find(refAllele);
-        
-            //block = nodePS->second;
-            if( nodePS != bkResult->end() ){
-                if((*bkResult)[refAllele] != 0 ){
-                    if((*variantType)[variant.position] == 0){
-                        if((*subNodeHP)[refAllele]==0)refCount++;
-                        else altCount++;
-                    }
-                    else if((*variantType)[variant.position] == 1){
-                        if((*subNodeHP)[refAllele]==0)refCount++;
-                        else altCount++;
-                    }
-                    else if((*variantType)[variant.position] == 2){
-                        continue;
-                    }
-                    else if((*variantType)[variant.position] == 3){
-                        if((*subNodeHP)[refAllele]==0)refCount+=0.1;
-                        else altCount+=0.1;
-                    }
-                    else if((*variantType)[variant.position] == 4){
-                        if((*subNodeHP)[refAllele]==0)refCount+=0.1;
-                        else altCount+=0.1;
-                    }
-                }
-            }
 
+        // loop all variant
+        for(const auto& variant : (*readIter).variantVec){
+            accumulateReadHaplotypeEvidence(variant, refCount, altCount);
         }
 
         // tag high confident reads
-        if( std::max(refCount,altCount)/(refCount+altCount) > params->readConfidence && (refCount + altCount) > 1 ){
+        if(std::max(refCount, altCount) / (refCount + altCount) > params->readConfidence && (refCount + altCount) > 1){
             // tag read with the corresponding haplotype
-            int belongHP = ( refCount > altCount ? 0 : 1 );
+            int belongHP = (refCount > altCount ? 0 : 1);
             (*readHpMap)[(*readIter).read_name] = belongHP;
-            
-            //readBlockHP[(*readIter).read_name][(*readIter).reference_start][block]=belongHP;
-            //readBlockHPcount[(*readIter).read_name][block][belongHP]++;
 
-            for(auto variantIter = (*readIter).variantVec.begin() ; variantIter != (*readIter).variantVec.end() ; variantIter++ ){
-                if( (*variantIter).allele == 0 || (*variantIter).allele == 1){
-                    (*hpAlleleCountMap)[belongHP][(*variantIter).position][(*variantIter).allele]++;
+            for(auto variantIter = (*readIter).variantVec.begin(); variantIter != (*readIter).variantVec.end(); variantIter++){
+                if((*variantIter).allele == 0 || (*variantIter).allele == 1){
+                    hpAlleleCountMap[belongHP][(*variantIter).position][(*variantIter).allele]++;
                 }
             }
         }
@@ -957,65 +928,61 @@ void VairiantGraph::readCorrection(){
             (*readHpMap)[(*readIter).read_name] = -1;
         }
     }
+}
 
-    /*
-    for(auto readIter = readBlockHP.begin() ; readIter != readBlockHP.end() ; readIter++ ){
-        
-        int max = 0;
-        for(auto blockIter = readBlockHPcount[readIter->first].begin() ; blockIter != readBlockHPcount[readIter->first].end() ; blockIter++ ){
-            if( (*blockIter).second.size() > max ){
-                max = (*blockIter).second.size();
-            }
+void VairiantGraph::reassignVariantHaplotypes(const HpAlleleCountMap& hpAlleleCountMap){
+    auto getHpAlleleCount = [&](int haplotype, int position, int allele){
+        auto hpIter = hpAlleleCountMap.find(haplotype);
+        if(hpIter == hpAlleleCountMap.end()){
+            return 0.0;
         }
 
-        std::cout<< readIter->first << "\t" << max;
-        
-        for(auto startIter = readIter->second.begin() ; startIter != readIter->second.end() ; startIter++ ){
-            std::cout<< "\t" << startIter->first << ",";
-            for(auto blockIter = startIter->second.begin() ; blockIter != startIter->second.end() ; blockIter++ ){
-                std::cout<< blockIter->first << "," <<  blockIter->second;
-            }
+        auto positionIter = hpIter->second.find(position);
+        if(positionIter == hpIter->second.end()){
+            return 0.0;
         }
-        std::cout<< "\n";
-    }
-    */
+
+        auto alleleIter = positionIter->second.find(allele);
+        if(alleleIter == positionIter->second.end()){
+            return 0.0;
+        }
+
+        return alleleIter->second;
+    };
 
     double snpConfidenceThreshold = params->snpConfidence;
 
     subNodeHP->clear();
-    
-    std::map<int,std::map<int,int>> hpAllele;
+
     // reassign allele result
-    for(auto variantIter = totalVariantInfo->begin() ; variantIter != totalVariantInfo->end() ; variantIter++ ){
+    for(auto variantIter = totalVariantInfo->begin(); variantIter != totalVariantInfo->end(); variantIter++){
         int position = variantIter->first;
         PosAllele refAllele = std::make_pair(position, 1);
         PosAllele altAllele = std::make_pair(position, 2);
-        
-        double hp1Ref = (*hpAlleleCountMap)[0][position][0];
-        double hp1Alt = (*hpAlleleCountMap)[0][position][1];
-        double hp2Ref = (*hpAlleleCountMap)[1][position][0];
-        double hp2Alt = (*hpAlleleCountMap)[1][position][1];
+
+        double hp1Ref = getHpAlleleCount(0, position, 0);
+        double hp1Alt = getHpAlleleCount(0, position, 1);
+        double hp2Ref = getHpAlleleCount(1, position, 0);
+        double hp2Alt = getHpAlleleCount(1, position, 1);
         double result1reads = hp1Ref + hp2Alt;
         double result2reads = hp2Ref + hp1Alt;
         double resultConfidence = std::max(result1reads, result2reads) / (result1reads + result2reads);
-        
+
         int hp1Result = -1;
         int hp2Result = -1;
-        
-        //std::cout << "RC\t" << position+1 << "\t" << result1reads << "\t" << result2reads << "\t" << resultConfidence << "\n" ;
-        
-        if( resultConfidence > snpConfidenceThreshold ){
-            if( result1reads > result2reads ){
+
+        if(resultConfidence > snpConfidenceThreshold){
+            if(result1reads > result2reads){
                 hp1Result = 0;
                 hp2Result = 1;
             }
-            else if( result1reads < result2reads ){
+            else if(result1reads < result2reads){
                 hp1Result = 1;
                 hp2Result = 0;
             }
         }
 
-        if( hp1Result != -1 && hp2Result != -1 ){
+        if(hp1Result != -1 && hp2Result != -1){
             (*subNodeHP)[refAllele] = hp1Result;
             (*subNodeHP)[altAllele] = hp2Result;
         }
@@ -1024,8 +991,12 @@ void VairiantGraph::readCorrection(){
             bkResult->erase(altAllele);
         }
     }
+}
 
-    delete hpAlleleCountMap;
+void VairiantGraph::readCorrection(){
+    HpAlleleCountMap hpAlleleCountMap;
+    assignReadHaplotypesAndCollectAlleleCounts(hpAlleleCountMap);
+    reassignVariantHaplotypes(hpAlleleCountMap);
 }
 
 void VairiantGraph::writingDotFile(std::string dotPrefix){
@@ -1102,7 +1073,7 @@ void VairiantGraph::phasingProcess(){
 
 Clip::Clip(std::string &chr, ClipCount &clipCount){
     this->chr = chr;
-    getCNVInterval(clipCount, chr);
+    getCNVInterval(clipCount);
 }
 
 Clip::~Clip(){
@@ -1125,106 +1096,96 @@ void Clip::updateThreshold(int upCount){
     }
 }
 
-void Clip::getCNVInterval(ClipCount &clipCount, std::string &chrName){
+void Clip::handleIdleState(int upCount, int downCount, int pos){
+    if(upCount >= CNV_PUSH_THRESHOLD && state.currCount == 0){
+        state.push = 1;
+        state.slowUp = 0;
+        state.slowDown = 1;
+        state.currCount = upCount - downCount;
+        state.candidateStartPos = pos;
+        state.candidateEndPos = pos + CNV_AREA_SIZE;
+        updateThreshold(upCount);
+    }
+    else if(upCount > downCount && state.currCount == 0){
+        state.push = 0;
+        state.slowUp = 1;
+        state.slowDown = 0;
+        state.currCount = upCount - downCount;
+        state.candidateStartPos = pos;
+        state.candidateEndPos = pos + CNV_AREA_SIZE;
+    }
+}
+
+void Clip::handleActiveState(int upCount, int downCount, int pos){
+    if(upCount > state.rejectCount){
+        state.push = 1;
+        state.slowUp = 0;
+        state.slowDown = 1;
+        updateThreshold(upCount);
+        state.candidateStartPos = pos;
+        state.candidateEndPos = pos + CNV_AREA_SIZE;
+    }
+    state.currCount = state.currCount + upCount - downCount;
+    if(state.currCount > CNV_EXTEND_THRESHOLD){
+        state.candidateEndPos = pos + CNV_AREA_SIZE;
+    }
+    if(downCount >= state.pullDownCount){
+        cnvVec.emplace_back(state.candidateStartPos, pos);
+        state.reset();
+    }
+    else if(state.currCount <= state.slowDownCount && pos <= state.candidateEndPos){
+        cnvVec.emplace_back(state.candidateStartPos, pos);
+        state.reset();
+    }
+    if(pos > state.candidateEndPos || state.currCount <= 0 || pos - state.candidateStartPos >= CNV_MAX_LENGTH){
+        state.reset();
+    }
+}
+
+void Clip::handleSlowUpState(int upCount, int downCount, int pos){
+    if(state.currCount > CNV_SLOWUP_COMMIT_THRESHOLD ? downCount >= state.currCount/4 : downCount >= CNV_PUSH_THRESHOLD){
+        cnvVec.emplace_back(state.candidateStartPos, pos);
+        state.reset();
+    }
+    else if(upCount >= CNV_PUSH_THRESHOLD){
+        state.push = 1;
+        state.slowUp = 0;
+        state.slowDown = 1;
+        state.currCount = upCount - downCount;
+        state.candidateStartPos = pos;
+        state.candidateEndPos = pos + CNV_AREA_SIZE;
+        updateThreshold(upCount);
+    }
+    else{
+        state.currCount = state.currCount + upCount - downCount;
+        if(state.currCount > CNV_EXTEND_THRESHOLD){
+            state.candidateEndPos = pos + CNV_AREA_SIZE;
+        }
+        if(pos > state.candidateEndPos || state.currCount <= 0 || pos - state.candidateStartPos >= CNV_MAX_LENGTH){
+            state.reset();
+        }
+    }
+}
+
+void Clip::getCNVInterval(ClipCount &clipCount){
     if (clipCount.empty()) {
         return;
     }
-    int upCount = 0;
-    int downCount = 0;
-    int AreaSize = 30000;
     state.reset();
 
-    clipCount[clipCount.rbegin()->first + AreaSize] = clipCount.rbegin()->second;
-    std::map<std::string, std::map<int,int>> cnvArea;
+    clipCount[clipCount.rbegin()->first + CNV_AREA_SIZE] = clipCount.rbegin()->second;
 
+    for(auto posIter = clipCount.begin(); posIter != clipCount.end(); posIter++){
+        int upCount   = posIter->second[FRONT];
+        int downCount = posIter->second[BACK];
+        int pos       = posIter->first;
 
-    for(auto posIter = clipCount.begin(); posIter != clipCount.end() ; posIter++ ){
-        upCount = posIter->second[FRONT];
-        downCount = posIter->second[BACK];
-
-        //if the current state is not push, not slowdown, and not slowup
-        if(!state.push && !state.slowDown && !state.slowUp){
-            //if the up count is greater than 5 and the current count is 0, then change the state to push and slow down
-            if(upCount >= 5 && state.currCount == 0){
-                state.push = 1;
-                state.slowUp = 0;
-                state.slowDown = 1;
-                state.currCount = upCount - downCount;
-                state.candidateStartPos = posIter->first;
-                state.candidateEndPos = posIter->first + AreaSize;
-                updateThreshold(upCount);
-            }
-            //if the up count is greater than the down count and the current count is 0, then change the state to slowup
-            else if(upCount > downCount && state.currCount == 0){
-                state.push = 0;
-                state.slowUp = 1;
-                state.slowDown = 0;
-                state.currCount = upCount - downCount;
-                state.candidateStartPos = posIter->first;
-                state.candidateEndPos = posIter->first + AreaSize;
-            }
-        }
-        //if the current state is push and slowdown
-        else if(state.push && state.slowDown){
-            //if the up count is greater than the reject count, then change the state to push
-            if(upCount > state.rejectCount){
-                state.push = 1;
-                state.slowUp = 0;
-                state.slowDown = 1;
-                updateThreshold(upCount);
-                state.candidateStartPos = posIter->first;
-                state.candidateEndPos = posIter->first + AreaSize;
-            }
-            //update the current count
-            state.currCount = state.currCount + upCount - downCount;
-            //if the current count is greater than 30, then change the candidate end position to the current position + AreaSize
-            if(state.currCount > 30){
-                state.candidateEndPos = posIter->first + AreaSize;
-            }
-            //if the down count is greater than the pull down count, then push the cnv to the vector
-            if(downCount >= state.pullDownCount){
-                cnvVec.emplace_back(state.candidateStartPos, posIter->first);
-                state.reset();
-            }
-            //if the current count is less than or equal to the slow down count and the current position is less than or equal to the candidate end position, then push the cnv to the vector
-            else if(state.currCount <= state.slowDownCount && posIter->first <= state.candidateEndPos){
-                cnvVec.emplace_back(state.candidateStartPos, posIter->first);            
-                state.reset();
-            }
-            //if the current position is greater than the candidate end position or the current count is less than or equal to 0 or the current position is greater than or equal to the candidate start position + 200000, then reset the state
-            if(posIter->first > state.candidateEndPos || state.currCount <= 0 || posIter->first - state.candidateStartPos >= 200000){
-                state.reset();
-            }
-        }
-        //if the current state is slow up
-        else if(state.slowUp){
-            //if the current count is greater than 20, then down count is greater than the current count / 4, then push the cnv to the vector
-            if(state.currCount > 20 ? downCount >= state.currCount/4 : downCount >= 5){
-                cnvVec.emplace_back(state.candidateStartPos, posIter->first);
-                state.reset();
-            }
-            //if the up count is greater than 5, then change the state to push and slow down
-            else if(upCount >= 5){
-                state.push = 1;
-                state.slowUp = 0;
-                state.slowDown = 1;
-                state.currCount = upCount - downCount;
-                state.candidateStartPos = posIter->first;
-                state.candidateEndPos = posIter->first + AreaSize;
-                updateThreshold(upCount);
-            }
-            else{
-                state.currCount = state.currCount + upCount - downCount;
-                //if the current count is greater than 30, then change the candidate end position to the current position + AreaSize
-                if(state.currCount > 30){
-                    state.candidateEndPos = posIter->first + AreaSize;
-                }
-                //if the current position is greater than the candidate end position or the current count is less than or equal to 0 or the current position is greater than or equal to the candidate start position + 200000, then reset the state
-                if(posIter->first > state.candidateEndPos || state.currCount <= 0 || posIter->first - state.candidateStartPos >= 200000){
-                    state.reset();
-                }
-            }
-        }
+        if(!state.push && !state.slowDown && !state.slowUp)
+            handleIdleState(upCount, downCount, pos);
+        else if(state.push && state.slowDown)
+            handleActiveState(upCount, downCount, pos);
+        else if(state.slowUp)
+            handleSlowUpState(upCount, downCount, pos);
     }
     clipCount.erase(--clipCount.end());
 }

--- a/PhasingGraph.h
+++ b/PhasingGraph.h
@@ -8,12 +8,18 @@
 
 typedef std::pair<int, int> PosAllele;
 typedef std::map<std::string, int> ReadBaseMap;
-using PosVec = std::vector<int>;
+using HpAlleleCountMap = std::map<int, std::map<int, std::map<double, double>>>;
+using PhasedBlocks = std::map<int, std::vector<int>>;
 
 class Clip{
     private:
         std::string chr;
-        PosVec CNVtoLOHInterval(SnpParser &snpMap);
+
+        static const int CNV_AREA_SIZE             = 30000;
+        static const int CNV_PUSH_THRESHOLD        = 5;
+        static const int CNV_EXTEND_THRESHOLD      = 30;
+        static const int CNV_MAX_LENGTH            = 200000;
+        static const int CNV_SLOWUP_COMMIT_THRESHOLD = 20;
 
         struct cnvState{
             cnvState():push(false),slowUp(false),slowDown(false),currCount(0),rejectCount(0),pullDownCount(0),slowDownCount(0),candidateStartPos(-1),candidateEndPos(-1){}
@@ -42,14 +48,15 @@ class Clip{
         };
         cnvState state;
         void updateThreshold(int upCount);
+        void handleIdleState(int upCount, int downCount, int pos);
+        void handleActiveState(int upCount, int downCount, int pos);
+        void handleSlowUpState(int upCount, int downCount, int pos);
 
     public:
         Clip(std::string &chr, ClipCount &inClipCount);
         ~Clip();
         std::vector<std::pair<int, int>> cnvVec;
-        void getCNVInterval(ClipCount &clipCount, std::string &chr);
-        PosVec detectLOH(SnpParser &snpMap);
-        std::string getChr() const { return chr;}
+        void getCNVInterval(ClipCount &clipCount);
 };
 
 class SubEdge{
@@ -166,7 +173,24 @@ class VairiantGraph{
         
         void readCorrection();
 
+        void accumulateReadHaplotypeEvidence(const Variant& variant, double& refCount, double& altCount);
+
+        void assignReadHaplotypesAndCollectAlleleCounts(HpAlleleCountMap& hpAlleleCountMap);
+
+        void reassignVariantHaplotypes(const HpAlleleCountMap& hpAlleleCountMap);
+
         void edgeConnectResult();
+
+        void scanVariantsAndBuildBlocks(
+            std::map<int, int>& hpResult,
+            PhasedBlocks& phasedBlocks,
+            std::vector<std::string>& outDotResult);
+
+        void materializeBlockResults(
+            const std::map<int, int>& hpResult,
+            const PhasedBlocks& phasedBlocks,
+            std::map<PosAllele, int>& outBkResult,
+            std::map<PosAllele, int>& outSubNodeHP);
 
         void calculateCnvMismatchRate(std::vector<ReadVariant>& in_readVariant, Clip &clip);
 
@@ -175,6 +199,12 @@ class VairiantGraph{
         void calculateAverageMismatchRate(const Clip& clip, const std::map<int, std::map<int, std::vector<int>>>& cnvReadMmrate, std::map<int, double>& missRateMap);
 
         void filterHighMismatchVariants(std::vector<ReadVariant>& in_readVariant, const Clip& clip, const std::map<int, double>& missRateMap);
+
+        void filterOverlappingAlignments(std::vector<ReadVariant>& in_readVariant);
+
+        void applyCnvFilter(std::vector<ReadVariant>& in_readVariant, Clip& clip);
+
+        void buildVariantGraph(std::vector<ReadVariant>& in_readVariant);
 
         bool isPositionInRange(int position, int start, int end);
         

--- a/PhasingProcess.cpp
+++ b/PhasingProcess.cpp
@@ -128,7 +128,7 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
             continue;
         }
         Clip *clip = new Clip((*chrIter), clipCount);
-        clip->getCNVInterval(clipCount, (*chrIter));
+        clip->getCNVInterval(clipCount);
         
 
         // create a graph object and prepare to phasing.
@@ -151,7 +151,8 @@ PhasingProcess::PhasingProcess(PhasingParameters params)
         readVariantVec.clear();
         readVariantVec.shrink_to_fit();
         delete vGraph;
-        
+        delete clip;
+
         std::cerr<< "(" << (*chrIter) << "," << difftime(time(NULL), chrbegin) << "s)";
     }
     hts_tpool_destroy(threadPool.pool);

--- a/Util.cpp
+++ b/Util.cpp
@@ -18,6 +18,41 @@ std::string getTargetString(std::string line, std::string start_sign, std::strin
     return line.substr(start,target_length);
 }
 
+int findFieldValueStart(const std::string &format, const std::string &sample,
+                        const std::string &tag) {
+  int colon_pos = 0;
+  int tag_pos = format.find(tag);
+  for (int i = 0; i < tag_pos; i++) {
+    if (format[i] == ':')
+      colon_pos++;
+  }
+  int current_colon = 0;
+  int value_start = 0;
+  for (unsigned int i = 0; i < sample.length(); i++) {
+    if (current_colon >= colon_pos)
+      break;
+    if (sample[i] == ':')
+      current_colon++;
+    value_start++;
+  }
+  return value_start;
+}
+
+bool isDangerIndel(int variant_pos, const std::string &ref, size_t ref_allele_len,
+                   size_t alt_allele_len) {
+  if (ref_allele_len <= 1 && alt_allele_len <= 1)
+    return false;
+
+  std::string repeat = ref.substr(variant_pos + 1, 2);
+  int ref_pos = variant_pos;
+  for (int i = 0; i < 5; i++) {
+    if (repeat[0] != ref[ref_pos + 1] || repeat[1] != ref[ref_pos + 2])
+      return false;
+    ref_pos += 2;
+  }
+  return true;
+}
+
 int homopolymerLength(int snp_pos, const std::string &ref_string){
     int homopolymer_length = 1;
     int ref_len = ref_string.length();

--- a/Util.h
+++ b/Util.h
@@ -108,6 +108,14 @@ struct less_than_key
 
 std::string getTargetString(std::string line, std::string start_sign, std::string end_sign);
 
+// Returns the character start position in `sample` for the value of `tag` in `format`.
+int findFieldValueStart(const std::string &format, const std::string &sample,
+                        const std::string &tag);
+
+// Marks indels in tandem repeats (2-mer repeated >= 5 times) as dangerous.
+bool isDangerIndel(int variant_pos, const std::string &ref, size_t ref_allele_len,
+                   size_t alt_allele_len);
+
 int homopolymerLength(int snp_pos, const std::string &ref_string);
 
 template <typename T>


### PR DESCRIPTION
### **Summary**

This PR performs a large-scale internal refactor across the three main LongPhase workflows: phase, modcall, and haplotag.

The refactor focuses on improving code readability, maintainability, and future extensibility while preserving the existing behavior. Large methods were decomposed into smaller, more focused helper functions. Repeated logic was consolidated into shared utilities, and dead code was removed throughout the codebase.

This is intended to be a behavior-preserving refactor. No algorithms, output formats, filtering behavior, haplotype assignment logic, methylation/modification handling, or BAM/VCF tag behavior were intentionally changed.

### **Main Changes**

**Phase**

The phase workflow was refactored to make the phasing pipeline easier to follow and maintain.

The main changes include:

* Decomposed large phasing-related methods into smaller helper functions.
* Consolidated duplicated parsing and scoring logic.
* Removed unused or unreachable code paths.
* Preserved the existing SNP / SV / MOD / indel handling behavior.
* Preserved the existing VCF output format and phasing results.

**Modcall**

The modcall workflow was refactored to reduce duplicated logic and make the modification-calling path easier to reason about.

The main changes include:

* Extracted repeated BAM parsing and modification-processing logic into helper functions.
* Consolidated shared utility logic used across modification-related paths.
* Removed dead code that was no longer used by the current implementation.
* Preserved the existing modification-calling behavior.
* Preserved the existing output format and tag behavior.

**Haplotag**

The haplotag workflow was refactored to improve structure and reduce duplicated per-read processing logic.

The main changes include:

* Decomposed large haplotagging methods into smaller helper functions.
* Consolidated shared logic for per-read decision making and output handling.
* Removed dead code and unused branches.
* Preserved the existing haplotype assignment behavior.
* Preserved the existing BAM/CRAM output behavior and tag behavior.

Shared utilities：

Common logic shared across multiple workflows was moved into shared utility functions where appropriate. This reduces duplicated implementation code and makes future changes easier to apply consistently across phase, modcall, and haplotag.

### **Behavior Compatibility**

This PR is intended to preserve all existing behavior.

The following were not intentionally changed:

* Phasing algorithms
* Modification-calling algorithms
* Haplotagging logic
* SNP / SV / MOD / indel handling
* Haplotype assignment behavior
* BAM / CRAM output behavior
* VCF data-row output
* BAM / VCF tag behavior
* Output file formats

### **Validation**

Because this refactor touched the internal implementation of all three main workflows, validation was done in two layers:

1. Step-by-step checks during the refactor.
2. Full regression comparisons against the original binary after the refactor.

During refactoring：

Each method was refactored one step at a time. Before each step, temporary instrumentation was used to capture and compare internal state against a pre-refactor baseline.

The checked internal states included：

* Per-read haplotype decisions
* Evidence counters
* CIGAR-level scoring digests
* Intermediate parsing results
* Final BAM content
* Per-read log output

Any discrepancy blocked the next refactor step.

After each section passed the internal checks, the temporary instrumentation was removed. A final end-to-end diff was then used to confirm that the complete output remained identical to the baseline before moving on to the next section.

### **Final regression**

The original v2.0.2 binary and the refactored binary were run side-by-side on identical inputs across multiple coverages and input combinations.

The comparison rule was strict:

* VCF header lines were excluded from comparison.
* All VCF data rows were required to be byte-for-byte identical.
* BAM / CRAM outputs were checked for readability.
* BAM / CRAM outputs were also checked for content equivalence.

All three main workflows passed the regression matrix.

The regression matrix was run on the following datasets:

* HG002 10x–60x
* H1437
* H2009
* HCC1395
* HCC1937
* HCC1954

**modcall**

Validated across the datasets listed above.

Result:

* All runs passed.
* No output mismatches were observed.

**phase**

Validated across the datasets listed above using 6 command-line parameter combinations covering SNP / SV / MOD / indel inputs, both individually and in combined paths.

Result:

* All runs passed.
* No output mismatches were observed.

**haplotag**

Validated across the datasets listed above.

Result:

* All runs passed.
* No output mismatches were observed.